### PR TITLE
Restructure nav tabs and profile screen for a unified UX and progressive Provider role activation.

### DIFF
--- a/apps/mobile/app/(tabs)/_layout.tsx
+++ b/apps/mobile/app/(tabs)/_layout.tsx
@@ -7,9 +7,12 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { useAuth } from '@/contexts/auth';
 
 export default function TabLayout() {
   const colorScheme = useColorScheme();
+  const { userProfile } = useAuth();
+  const isProvider = userProfile?.role === 'provider' || userProfile?.role === 'both';
 
   return (
     <Tabs
@@ -30,35 +33,38 @@ export default function TabLayout() {
         name="index"
         options={{
           title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          tabBarIcon: ({ color }: { color: string }) => <IconSymbol size={28} name="house.fill" color={color} />,
         }}
       />
-      <Tabs.Screen
-        name="search"
-        options={{
-          title: 'Search',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="magnifyingglass" color={color} />,
-        }}
-      />
+
       <Tabs.Screen
         name="booked"
         options={{
           title: 'Booked',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="calendar" color={color} />,
+          tabBarIcon: ({ color }: { color: string }) => <IconSymbol size={28} name="calendar" color={color} />,
         }}
       />
       <Tabs.Screen
         name="messages"
         options={{
           title: 'Messages',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="message" color={color} />,
+          tabBarIcon: ({ color }: { color: string }) => <IconSymbol size={28} name="message" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="business"
+        options={{
+          title: 'Business',
+          tabBarIcon: ({ color }: { color: string }) => <IconSymbol size={28} name="briefcase" color={color} />,
+          // When href undefined, Expo will use the default href and tab is shown. Otherwise, tab is hidden.
+          href: isProvider ? undefined : null, 
         }}
       />
       <Tabs.Screen
         name="account"
         options={{
           title: 'Account',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.fill" color={color} />,
+          tabBarIcon: ({ color }: { color: string }) => <IconSymbol size={28} name="person.fill" color={color} />,
         }}
       />
     </Tabs>

--- a/apps/mobile/app/(tabs)/account.tsx
+++ b/apps/mobile/app/(tabs)/account.tsx
@@ -1,16 +1,15 @@
-import { View, StyleSheet, SafeAreaView, Image, ScrollView, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { View, StyleSheet, SafeAreaView, Image, ScrollView, TouchableOpacity, Alert, ActivityIndicator, Switch } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Appearance } from 'react-native';
 import { Colors } from '@/constants/Colors';
-import { ACCOUNT_MENU_ITEMS } from '@/constants/account';
-import { MenuItem } from '@/types/user';
-import { SegmentedToggle } from '@/components/ui/SegmentedToggle';
+import { PROFILE_MENU_ITEMS } from '@/constants/account';
 import { useState } from 'react';
 import { MenuSection } from '@/components/ui/MenuSection';
 import { useAuth } from '@/contexts/auth';
 import { Button } from '@lazone/ui';
+import { Ionicons } from '@expo/vector-icons';
 
 export default function AccountScreen() {
   const router = useRouter();
@@ -18,10 +17,9 @@ export default function AccountScreen() {
   const colorScheme = Appearance.getColorScheme();
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
   const styles = createStyles(theme, colorScheme);
-  
-  const [userRole, setUserRole] = useState<'requester' | 'provider'>(
-    userProfile?.role === 'provider' ? 'provider' : 'requester'
-  );
+
+  const isProvider = userProfile?.role === 'provider' || userProfile?.role === 'both';
+  const [businessVisible, setBusinessVisible] = useState(true);
 
   // Show a loading indicator while the initial auth check is happening.
   if (loading) {
@@ -33,7 +31,6 @@ export default function AccountScreen() {
   }
 
   // If auth check is done, but there's no profile, show a specific message.
-  // This is the state you were seeing.
   if (!userProfile) {
     return (
       <SafeAreaView style={styles.loadingContainer}>
@@ -45,7 +42,7 @@ export default function AccountScreen() {
   }
 
   const navigateTo = (route: string) => {
-    router.push(route);
+    router.push(route as any);
   };
 
   const handleProfilePress = () => {
@@ -60,23 +57,20 @@ export default function AccountScreen() {
   const handleLogout = async () => {
     try {
       await logout();
-      // The root layout will handle redirection automatically.
     } catch (error) {
       Alert.alert("Logout Failed", "An error occurred while logging out.");
     }
   };
 
-  // Filter resources based on current role
-  const getFilteredResources = (items: MenuItem[], role: 'requester' | 'provider') => {
-    return items.filter(item => {
-      if (!item.roleAccess) return true;
-      return item.roleAccess.includes(role);
-    });
+  const handleToggleBusinessVisibility = (value: boolean) => {
+    setBusinessVisible(value);
+    // TODO: persist this to Firestore on the provider document
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.scrollContent}>
+      <ScrollView style={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        {/* ── Profile header ─────────────────────────────── */}
         <TouchableOpacity onPress={handleProfilePress} activeOpacity={0.7}>
           <ThemedView style={styles.header}>
             <Image
@@ -90,54 +84,87 @@ export default function AccountScreen() {
               <ThemedText>{user?.email}</ThemedText>
               <ThemedText>{userProfile.phoneNumber}</ThemedText>
             </View>
+            <Ionicons name="chevron-forward" size={20} color={theme.icon} />
           </ThemedView>
         </TouchableOpacity>
 
-        <SegmentedToggle
-          options={[
-            { label: 'Requester', value: 'requester' },
-            { label: 'Provider', value: 'provider' },
-          ]}
-          value={userRole}
-          onChange={(role) => setUserRole(role as 'requester' | 'provider')}
+        {/* ── General (everyone) ──────────────────────────── */}
+        <MenuSection
+          items={PROFILE_MENU_ITEMS.general}
+          onPress={navigateTo}
+          styles={styles}
         />
 
-        {/* Show different menu sections based on role */}
-        {userRole === 'requester' ? (
-          <MenuSection
-            items={ACCOUNT_MENU_ITEMS.requester}
-            onPress={navigateTo}
-            styles={styles}
-          />
-        ) : (
-          <MenuSection
-            items={ACCOUNT_MENU_ITEMS.provider || []}
-            onPress={navigateTo}
-            styles={styles}
-          />
-        )}
-
+        {/* ── Settings (everyone) ─────────────────────────── */}
         <MenuSection
           title="Settings"
-          items={ACCOUNT_MENU_ITEMS.settings}
+          items={PROFILE_MENU_ITEMS.settings}
           onPress={navigateTo}
           styles={styles}
         />
 
+        {/* ── Business visibility toggle (providers only) ── */}
+        {isProvider && (
+          <ThemedView style={styles.toggleSection}>
+            <View style={styles.toggleRow}>
+              <View style={styles.toggleLeft}>
+                <Ionicons name="storefront-outline" size={24} style={styles.menuIcon} />
+                <View>
+                  <ThemedText type="defaultSemiBold">Business Visibility</ThemedText>
+                  <ThemedText style={styles.toggleHint}>
+                    {businessVisible ? 'Your business is visible to clients' : 'Your business is hidden from clients'}
+                  </ThemedText>
+                </View>
+              </View>
+              <Switch
+                value={businessVisible}
+                onValueChange={handleToggleBusinessVisibility}
+                trackColor={{ false: '#767577', true: '#0A58A5' }}
+                thumbColor="#fff"
+              />
+            </View>
+          </ThemedView>
+        )}
+
+        {/* ── Support (everyone) ──────────────────────────── */}
         <MenuSection
-          title="Resources"
-          items={getFilteredResources(ACCOUNT_MENU_ITEMS.resources, userRole)}
+          title="Support"
+          items={PROFILE_MENU_ITEMS.support}
           onPress={navigateTo}
           styles={styles}
         />
 
-        <Button label="Logout" onPress={handleLogout} style={{marginTop: 20}}/>
+        {/* ── Become a Provider (requesters only) ─────────── */}
+        {!isProvider && (
+          <TouchableOpacity
+            style={styles.becomeProviderCard}
+            activeOpacity={0.7}
+            onPress={() => router.push('/provider/registration')}
+          >
+            <Ionicons name="briefcase-outline" size={24} color="#0A58A5" style={{ marginRight: 12 }} />
+            <View style={{ flex: 1 }}>
+              <ThemedText type="defaultSemiBold">Become a Provider</ThemedText>
+              <ThemedText style={styles.becomeProviderHint}>
+                Offer your services and start earning
+              </ThemedText>
+            </View>
+            <Ionicons name="chevron-forward" size={20} color={theme.icon} />
+          </TouchableOpacity>
+        )}
+
+        <Button label="Logout" onPress={handleLogout} style={{ marginTop: 20 }} />
+
+        {/* Bottom spacing */}
+        <View style={{ height: 32 }} />
       </ScrollView>
     </SafeAreaView>
   );
 }
 
 function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefined) {
+  const cardBg = colorScheme === 'dark' ? '#1c1c1e' : theme.background;
+  const borderClr = colorScheme === 'dark' ? '#333' : '#ccc';
+
   return StyleSheet.create({
     container: {
       flex: 1,
@@ -157,14 +184,10 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
       padding: 16,
       marginBottom: 24,
       borderRadius: 12,
-      backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : theme.background,
-      // backgroundColor: theme.background,
-      borderColor: colorScheme === 'dark' ? '#333' : '#ccc',
+      backgroundColor: cardBg,
+      borderColor: borderClr,
       borderWidth: 1,
       marginTop: 16,
-      paddingBottom: 16,
-      paddingTop: 16,
-      paddingHorizontal: 16,
     },
     avatar: {
       width: 64,
@@ -184,8 +207,7 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
       paddingVertical: 12,
       paddingHorizontal: 16,
       borderRadius: 8,
-      backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : theme.background,
-      // backgroundColor:theme.background,
+      backgroundColor: cardBg,
     },
     sectionWithoutTitle: {
       paddingTop: 0,
@@ -215,6 +237,48 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
       marginLeft: 36,
       marginRight: 25,
       marginVertical: 8,
+    },
+
+    // ── Business visibility toggle ──
+    toggleSection: {
+      marginBottom: 24,
+      paddingVertical: 14,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+      backgroundColor: cardBg,
+    },
+    toggleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
+    toggleLeft: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flex: 1,
+      marginRight: 12,
+    },
+    toggleHint: {
+      fontSize: 12,
+      opacity: 0.5,
+      marginTop: 2,
+    },
+
+    // ── Become a Provider CTA ──
+    becomeProviderCard: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      padding: 16,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: '#0A58A5',
+      backgroundColor: colorScheme === 'dark' ? '#0a2540' : '#eaf3fc',
+      marginBottom: 8,
+    },
+    becomeProviderHint: {
+      fontSize: 13,
+      opacity: 0.6,
+      marginTop: 2,
     },
   });
 }

--- a/apps/mobile/app/(tabs)/account.tsx
+++ b/apps/mobile/app/(tabs)/account.tsx
@@ -152,7 +152,7 @@ export default function AccountScreen() {
           </TouchableOpacity>
         )}
 
-        <Button label="Logout" onPress={handleLogout} style={{ marginTop: 20 }} />
+        {/* <Button label="Logout" onPress={handleLogout} style={{ marginTop: 20 }} /> */}
 
         {/* Bottom spacing */}
         <View style={{ height: 32 }} />

--- a/apps/mobile/app/(tabs)/business.tsx
+++ b/apps/mobile/app/(tabs)/business.tsx
@@ -1,0 +1,695 @@
+import {
+  View,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  TouchableOpacity,
+  Appearance,
+  Image,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { Colors } from '@/constants/Colors';
+import { useAuth } from '@/contexts/auth';
+import { Ionicons } from '@expo/vector-icons';
+import { Button } from '@lazone/ui';
+
+// ─── Static Data (to be replaced with hooks / Firestore later) ───────────────
+
+const STATS = {
+  profileViews: 128,
+  totalEarnings: '475,000 CFA',
+  averageRating: 4.7,
+  completedJobs: 34,
+};
+
+const INCOMING_REQUESTS = [
+  {
+    id: 'req-1',
+    clientName: 'Aminata Ouédraogo',
+    clientAvatar: null,
+    serviceName: 'Kitchen Plumbing Repair',
+    requestedDate: '2026-02-20T10:00:00',
+    message: 'My kitchen sink has been leaking for a couple days. Available Friday morning.',
+    createdAt: '2026-02-17T08:30:00',
+  },
+  {
+    id: 'req-2',
+    clientName: 'Moussa Traoré',
+    clientAvatar: null,
+    serviceName: 'Bathroom Tiling',
+    requestedDate: '2026-02-22T14:00:00',
+    message: 'Need the bathroom floor re-tiled. About 8 m².',
+    createdAt: '2026-02-16T19:45:00',
+  },
+];
+
+const UPCOMING_BOOKINGS = [
+  {
+    id: 'bk-1',
+    clientName: 'Fatou Compaoré',
+    serviceName: 'Electrical Wiring',
+    scheduledDate: '2026-02-19T09:00:00',
+    status: 'confirmed' as const,
+    price: '120,000 CFA',
+  },
+  {
+    id: 'bk-2',
+    clientName: 'Ibrahim Kaboré',
+    serviceName: 'Light Fixture Installation',
+    scheduledDate: '2026-02-21T15:30:00',
+    status: 'confirmed' as const,
+    price: '45,000 CFA',
+  },
+  {
+    id: 'bk-3',
+    clientName: 'Awa Sané',
+    serviceName: 'Full Apartment Rewiring',
+    scheduledDate: '2026-02-25T08:00:00',
+    status: 'confirmed' as const,
+    price: '310,000 CFA',
+  },
+];
+
+const RECENT_EARNINGS = [
+  { id: 'e-1', clientName: 'Jean-Paul Nikiéma', service: 'Outlet Repair', amount: '35,000 CFA', date: '2026-02-15' },
+  { id: 'e-2', clientName: 'Mariam Sawadogo', service: 'Generator Hookup', amount: '90,000 CFA', date: '2026-02-12' },
+  { id: 'e-3', clientName: 'David Zoungrana', service: 'Panel Upgrade', amount: '150,000 CFA', date: '2026-02-08' },
+];
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatDate(isoString: string) {
+  const date = new Date(isoString);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatTime(isoString: string) {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true }).toLowerCase();
+}
+
+function timeAgo(isoString: string) {
+  const now = new Date();
+  const diff = now.getTime() - new Date(isoString).getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  if (hours < 1) return 'Just now';
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export default function BusinessScreen() {
+  const router = useRouter();
+  const { userProfile } = useAuth();
+  const colorScheme = Appearance.getColorScheme();
+  const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
+  const styles = createStyles(theme, colorScheme);
+
+  const isProvider = userProfile?.role === 'provider' || userProfile?.role === 'both';
+
+  // Non-provider users see a prompt to register
+  if (!isProvider) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.activationContainer}>
+          <Ionicons name="briefcase-outline" size={64} color={theme.icon} style={{ marginBottom: 16 }} />
+          <ThemedText type="subtitle" style={styles.activationTitle}>
+            Start your business on LaZone
+          </ThemedText>
+          <ThemedText style={styles.activationSubtitle}>
+            Register as a service provider to manage bookings, track earnings, and grow your client base.
+          </ThemedText>
+          <Button
+            label="Become a Provider"
+            onPress={() => router.push('/provider/registration')}
+            style={styles.activationButton}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        {/* ── Header ────────────────────────────────────── */}
+        <View style={styles.titleRow}>
+          <ThemedText type="title" style={styles.title}>Business</ThemedText>
+          <TouchableOpacity onPress={() => router.push('/provider/registration?editMode=true')}>
+            <Ionicons name="settings-outline" size={24} color={theme.text} />
+          </TouchableOpacity>
+        </View>
+
+        {/* ── Performance Metrics ────────────────────────── */}
+        <View style={styles.metricsGrid}>
+          <MetricCard
+            icon="eye-outline"
+            label="Profile Views"
+            value={String(STATS.profileViews)}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <MetricCard
+            icon="cash-outline"
+            label="Earnings"
+            value={STATS.totalEarnings}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <MetricCard
+            icon="star-outline"
+            label="Avg Rating"
+            value={String(STATS.averageRating)}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <MetricCard
+            icon="checkmark-done-outline"
+            label="Completed"
+            value={String(STATS.completedJobs)}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+        </View>
+
+        {/* ── Incoming Requests ──────────────────────────── */}
+        <SectionHeader
+          title="Incoming Requests"
+          count={INCOMING_REQUESTS.length}
+          theme={theme}
+        />
+        {INCOMING_REQUESTS.length === 0 ? (
+          <ThemedView style={styles.emptyCard}>
+            <ThemedText style={styles.emptyText}>No pending requests</ThemedText>
+          </ThemedView>
+        ) : (
+          INCOMING_REQUESTS.map((req) => (
+            <ThemedView
+              key={req.id}
+              style={styles.requestCard}
+              lightColor={theme.background}
+              darkColor="#1c1c1e"
+            >
+              <View style={styles.requestHeader}>
+                <View style={styles.requestClient}>
+                  <View style={styles.avatarPlaceholder}>
+                    <Ionicons name="person" size={18} color="#fff" />
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <ThemedText type="defaultSemiBold">{req.clientName}</ThemedText>
+                    <ThemedText style={styles.requestService}>{req.serviceName}</ThemedText>
+                  </View>
+                  <ThemedText style={styles.timeAgo}>{timeAgo(req.createdAt)}</ThemedText>
+                </View>
+              </View>
+              <ThemedText style={styles.requestMessage} numberOfLines={2}>
+                "{req.message}"
+              </ThemedText>
+              <View style={styles.requestMeta}>
+                <View style={styles.requestDateRow}>
+                  <Ionicons name="calendar-outline" size={14} color={theme.icon} />
+                  <ThemedText style={styles.requestDateText}>
+                    {formatDate(req.requestedDate)} at {formatTime(req.requestedDate)}
+                  </ThemedText>
+                </View>
+              </View>
+              <View style={styles.requestActions}>
+                <TouchableOpacity style={styles.declineButton}>
+                  <ThemedText style={styles.declineText}>Decline</ThemedText>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.acceptButton}>
+                  <ThemedText style={styles.acceptText}>Accept</ThemedText>
+                </TouchableOpacity>
+              </View>
+            </ThemedView>
+          ))
+        )}
+
+        {/* ── Upcoming Bookings ──────────────────────────── */}
+        <SectionHeader
+          title="Upcoming Bookings"
+          count={UPCOMING_BOOKINGS.length}
+          theme={theme}
+        />
+        {UPCOMING_BOOKINGS.map((booking) => (
+          <ThemedView
+            key={booking.id}
+            style={styles.bookingCard}
+            lightColor={theme.background}
+            darkColor="#1c1c1e"
+          >
+            <View style={styles.bookingRow}>
+              <View style={{ flex: 1 }}>
+                <ThemedText type="defaultSemiBold">{booking.clientName}</ThemedText>
+                <ThemedText style={styles.bookingService}>{booking.serviceName}</ThemedText>
+                <View style={styles.bookingDateRow}>
+                  <Ionicons name="calendar-outline" size={14} color={theme.icon} />
+                  <ThemedText style={styles.bookingDateText}>
+                    {formatDate(booking.scheduledDate)} at {formatTime(booking.scheduledDate)}
+                  </ThemedText>
+                </View>
+              </View>
+              <View style={styles.bookingRight}>
+                <ThemedText type="defaultSemiBold" style={styles.bookingPrice}>
+                  {booking.price}
+                </ThemedText>
+                <View style={styles.confirmedBadge}>
+                  <ThemedText style={styles.confirmedText}>Confirmed</ThemedText>
+                </View>
+              </View>
+            </View>
+          </ThemedView>
+        ))}
+
+        {/* ── Recent Earnings ────────────────────────────── */}
+        <SectionHeader title="Recent Earnings" theme={theme} />
+        <ThemedView
+          style={styles.earningsCard}
+          lightColor={theme.background}
+          darkColor="#1c1c1e"
+        >
+          {RECENT_EARNINGS.map((earning, index) => (
+            <View key={earning.id}>
+              <View style={styles.earningRow}>
+                <View style={{ flex: 1 }}>
+                  <ThemedText type="defaultSemiBold">{earning.service}</ThemedText>
+                  <ThemedText style={styles.earningClient}>{earning.clientName}</ThemedText>
+                </View>
+                <View style={styles.earningRight}>
+                  <ThemedText type="defaultSemiBold" style={styles.earningAmount}>
+                    {earning.amount}
+                  </ThemedText>
+                  <ThemedText style={styles.earningDate}>{formatDate(earning.date)}</ThemedText>
+                </View>
+              </View>
+              {index < RECENT_EARNINGS.length - 1 && <View style={styles.divider} />}
+            </View>
+          ))}
+        </ThemedView>
+
+        {/* ── Quick Actions ──────────────────────────────── */}
+        <SectionHeader title="Manage" theme={theme} />
+        <View style={styles.quickActionsGrid}>
+          <QuickActionCard
+            icon="images-outline"
+            label="Portfolio"
+            onPress={() => router.push('/provider/registration?editMode=true')}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <QuickActionCard
+            icon="pricetags-outline"
+            label="Services & Pricing"
+            onPress={() => router.push('/provider/registration?editMode=true')}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <QuickActionCard
+            icon="star-outline"
+            label="Reviews"
+            onPress={() => router.push('/provider/reviews')}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+          <QuickActionCard
+            icon="person-outline"
+            label="Public Profile"
+            onPress={() => router.push('/provider/preview')}
+            theme={theme}
+            colorScheme={colorScheme}
+          />
+        </View>
+
+        {/* Bottom spacing for tab bar */}
+        <View style={{ height: 32 }} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function MetricCard({
+  icon,
+  label,
+  value,
+  theme,
+  colorScheme,
+}: {
+  icon: string;
+  label: string;
+  value: string;
+  theme: any;
+  colorScheme: string | null | undefined;
+}) {
+  return (
+    <View
+      style={[
+        metricStyles.card,
+        { backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : theme.background },
+      ]}
+    >
+      <Ionicons name={icon as any} size={22} color="#0A58A5" style={metricStyles.icon} />
+      <ThemedText type="defaultSemiBold" style={metricStyles.value}>
+        {value}
+      </ThemedText>
+      <ThemedText style={metricStyles.label}>{label}</ThemedText>
+    </View>
+  );
+}
+
+const metricStyles = StyleSheet.create({
+  card: {
+    width: '48%',
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+  },
+  icon: { marginBottom: 8 },
+  value: { fontSize: 18, marginBottom: 2 },
+  label: { fontSize: 13, opacity: 0.6 },
+});
+
+function SectionHeader({
+  title,
+  count,
+  theme,
+}: {
+  title: string;
+  count?: number;
+  theme: any;
+}) {
+  return (
+    <View style={sectionHeaderStyles.row}>
+      <ThemedText type="subtitle" style={sectionHeaderStyles.title}>
+        {title}
+      </ThemedText>
+      {count !== undefined && (
+        <View style={sectionHeaderStyles.badge}>
+          <ThemedText style={sectionHeaderStyles.badgeText}>{count}</ThemedText>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const sectionHeaderStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 24,
+    marginBottom: 12,
+  },
+  title: { flex: 1 },
+  badge: {
+    backgroundColor: '#0A58A5',
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+    minWidth: 26,
+    alignItems: 'center',
+  },
+  badgeText: { color: '#fff', fontSize: 13, fontWeight: '600' },
+});
+
+function QuickActionCard({
+  icon,
+  label,
+  onPress,
+  theme,
+  colorScheme,
+}: {
+  icon: string;
+  label: string;
+  onPress: () => void;
+  theme: any;
+  colorScheme: string | null | undefined;
+}) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.7}
+      style={[
+        quickActionStyles.card,
+        { backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : theme.background },
+      ]}
+    >
+      <Ionicons name={icon as any} size={26} color="#0A58A5" style={quickActionStyles.icon} />
+      <ThemedText style={quickActionStyles.label}>{label}</ThemedText>
+    </TouchableOpacity>
+  );
+}
+
+const quickActionStyles = StyleSheet.create({
+  card: {
+    width: '48%',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 90,
+  },
+  icon: { marginBottom: 8 },
+  label: { fontSize: 14, textAlign: 'center' },
+});
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefined) {
+  const cardBorder = colorScheme === 'dark' ? '#333' : '#e0e0e0';
+
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    scrollContent: {
+      padding: 16,
+    },
+    titleRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginTop: 12,
+      marginBottom: 4,
+    },
+    title: {
+      fontSize: 28,
+    },
+
+    // ── Activation (non-provider) ──
+    activationContainer: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: 32,
+    },
+    activationTitle: {
+      textAlign: 'center',
+      marginBottom: 12,
+    },
+    activationSubtitle: {
+      textAlign: 'center',
+      opacity: 0.6,
+      marginBottom: 24,
+      lineHeight: 22,
+    },
+    activationButton: {
+      paddingHorizontal: 32,
+    },
+
+    // ── Metric grid ──
+    metricsGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+      marginTop: 16,
+    },
+
+    // ── Request cards ──
+    requestCard: {
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 12,
+      borderWidth: 1,
+      borderColor: cardBorder,
+    },
+    requestHeader: {
+      marginBottom: 8,
+    },
+    requestClient: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    avatarPlaceholder: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: '#0A58A5',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: 10,
+    },
+    requestService: {
+      fontSize: 13,
+      opacity: 0.6,
+    },
+    timeAgo: {
+      fontSize: 12,
+      opacity: 0.5,
+    },
+    requestMessage: {
+      fontSize: 14,
+      fontStyle: 'italic',
+      opacity: 0.7,
+      marginBottom: 10,
+    },
+    requestMeta: {
+      marginBottom: 12,
+    },
+    requestDateRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+    },
+    requestDateText: {
+      fontSize: 13,
+      opacity: 0.6,
+    },
+    requestActions: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      gap: 10,
+    },
+    declineButton: {
+      borderWidth: 1,
+      borderColor: cardBorder,
+      borderRadius: 8,
+      paddingVertical: 8,
+      paddingHorizontal: 20,
+    },
+    declineText: {
+      fontSize: 14,
+      fontWeight: '500',
+    },
+    acceptButton: {
+      backgroundColor: '#0A58A5',
+      borderRadius: 8,
+      paddingVertical: 8,
+      paddingHorizontal: 20,
+    },
+    acceptText: {
+      color: '#fff',
+      fontSize: 14,
+      fontWeight: '600',
+    },
+
+    // ── Booking cards ──
+    bookingCard: {
+      borderRadius: 12,
+      padding: 16,
+      marginBottom: 10,
+      borderWidth: 1,
+      borderColor: cardBorder,
+    },
+    bookingRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    bookingService: {
+      fontSize: 13,
+      opacity: 0.6,
+      marginTop: 2,
+    },
+    bookingDateRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      marginTop: 6,
+    },
+    bookingDateText: {
+      fontSize: 13,
+      opacity: 0.6,
+    },
+    bookingRight: {
+      alignItems: 'flex-end',
+    },
+    bookingPrice: {
+      fontSize: 14,
+      color: '#0A58A5',
+    },
+    confirmedBadge: {
+      backgroundColor: '#e6f4ea',
+      borderRadius: 6,
+      paddingHorizontal: 8,
+      paddingVertical: 3,
+      marginTop: 6,
+    },
+    confirmedText: {
+      color: '#1a7f37',
+      fontSize: 12,
+      fontWeight: '600',
+    },
+
+    // ── Earnings ──
+    earningsCard: {
+      borderRadius: 12,
+      padding: 16,
+      borderWidth: 1,
+      borderColor: cardBorder,
+    },
+    earningRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 10,
+    },
+    earningClient: {
+      fontSize: 13,
+      opacity: 0.5,
+      marginTop: 2,
+    },
+    earningRight: {
+      alignItems: 'flex-end',
+    },
+    earningAmount: {
+      fontSize: 14,
+      color: '#1a7f37',
+    },
+    earningDate: {
+      fontSize: 12,
+      opacity: 0.5,
+      marginTop: 2,
+    },
+    divider: {
+      height: 0.5,
+      backgroundColor: colorScheme === 'dark' ? '#444' : '#E0E0E0',
+    },
+
+    // ── Quick actions ──
+    quickActionsGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      justifyContent: 'space-between',
+    },
+
+    // ── Empty state ──
+    emptyCard: {
+      borderRadius: 12,
+      padding: 24,
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: cardBorder,
+    },
+    emptyText: {
+      opacity: 0.5,
+    },
+  });
+}

--- a/apps/mobile/app/(tabs)/search.txt
+++ b/apps/mobile/app/(tabs)/search.txt
@@ -1,3 +1,5 @@
+//No longer needed. Can use the code for reference if we want to for home search feature.
+//Changed extension to prevent expo from loading it without being asked.
 import { View, StyleSheet, Appearance, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { useState } from 'react';
 import { useRouter } from 'expo-router';

--- a/apps/mobile/app/account/info.tsx
+++ b/apps/mobile/app/account/info.tsx
@@ -1,71 +1,54 @@
-import { View, StyleSheet, Alert, Pressable, ActivityIndicator, ScrollView, Appearance } from 'react-native';
+import { View, StyleSheet, Alert, Pressable, ScrollView, Appearance } from 'react-native';
 import React, { useState, useEffect } from 'react';
-import { useRouter, useLocalSearchParams } from 'expo-router';
 import { useAuth } from '@/contexts/auth';
 import { Button } from '@lazone/ui';
-import EditableField from '../../components/account/EditableField';
 import ProfileAvatar from '../../components/account/ProfileAvatar';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import EditInfoPopup from '../../components/account/EditInfoPopup';
 import { Colors } from '@/constants/Colors';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useNavigation } from '@react-navigation/native';
 
-const STORAGE_KEY = 'user-info';
+export default function AccountInfoScreen() {// router.replace('/(auth)/login');
+	const { user, userProfile, logout } = useAuth();
+	const [editPopupVisible, setEditPopupVisible] = useState(false);
+	const navigation = useNavigation();
 
-export default function AccountInfoScreen() {
-	const params = useLocalSearchParams();
-	const userProfile = params.userProfile ? JSON.parse(params.userProfile as string) : null;
-
-	const [name, setName] = useState(userProfile?.firstName + ' ' + userProfile?.lastName || '');
-	const [email, setEmail] = useState(userProfile?.email || '');
-	const [phone, setPhone] = useState(userProfile?.phone || '');
-	const [avatar, setAvatar] = useState<string | null>(userProfile?.avatar || null);
-	const [saving, setSaving] = useState(false);
-	const { logout } = useAuth();
-	const router = useRouter();
 	const colorScheme = Appearance.getColorScheme();
 	const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
 	const styles = createStyles(theme, colorScheme);
-	const navigation = useNavigation();
+
+	const firstName = userProfile?.firstName ?? '';
+	const lastName = userProfile?.lastName ?? '';
+	const fullName = [firstName, lastName].filter(Boolean).join(' ');
+	const email = user?.email ?? '';
+	const phone = userProfile?.phoneNumber ?? '';
+	const avatar = userProfile?.avatar ?? null;
 
 	useEffect(() => {
 		navigation.setOptions({ title: 'Account Info' });
 	}, []);
 
-	// Save to local storage (Todo: replace with API)
-	const handleSave = async () => {
-		setSaving(true);
-		const payload = { name, email, phone, avatar };
-
-		try {
-			//TODO:Replace this with API later
-			await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-			Alert.alert('Success', 'Your changes have been saved!');
-		} catch (err) {
-			Alert.alert('Error', 'Could not save your info');
-		}
-
-		setSaving(false);
-	};
+	const editData = { firstName, lastName, email, phone };
 
 	return (
 		<ScrollView contentContainerStyle={styles.container}>
-			<ProfileAvatar uri={avatar} onChange={setAvatar} />
-			<EditableField value={name} onChangeText={setName} />
-			<EditableField value={email} onChangeText={setEmail} keyboardType="email-address" />
-			<EditableField value={phone} onChangeText={setPhone} keyboardType="phone-pad" />
+			<ProfileAvatar uri={avatar} onChange={() => setEditPopupVisible(true)} />
+
+			<View style={styles.infoSection}>
+				<InfoRow label="Name" value={fullName} placeholder="No name provided" theme={theme} />
+				<View style={styles.divider} />
+				<InfoRow label="Email" value={email} placeholder="No email on file" theme={theme} />
+				<View style={styles.divider} />
+				<InfoRow label="Phone" value={phone} placeholder="No phone number on file" theme={theme} />
+			</View>
 
 			<View style={styles.buttonContainer}>
-				{saving ? (
-					<ActivityIndicator size="large" color={theme.tint} />
-				) : (
-					<Button
-						label="Save Changes"
-						onPress={handleSave}
-						variant="primary"
-					/>
-				)}
+				<Button
+					label="Edit Information"
+					onPress={() => setEditPopupVisible(true)}
+					variant="primary"
+				/>
 			</View>
 
 			<ThemedText type="subtitle" style={styles.sectionTitle}>Account Management</ThemedText>
@@ -93,22 +76,72 @@ export default function AccountInfoScreen() {
 			<Pressable
 				style={styles.logout}
 				onPress={() => {
-					logout();
-					router.replace('/(auth)/login');
+					Alert.alert(
+						'Logout',
+						'Are you sure you want to logout?',
+						[
+							{ text: 'Cancel', style: 'cancel' },
+							{ text: 'Logout', style: 'destructive', onPress: () => logout() },
+						]
+					);
 				}}
 			>
 				<ThemedText style={styles.logoutText}>⎋ Logout</ThemedText>
 			</Pressable>
+
+			<EditInfoPopup
+				visible={editPopupVisible}
+				onClose={() => setEditPopupVisible(false)}
+				initialData={editData}
+			/>
 		</ScrollView>
 	);
 }
 
-function createStyles(theme, colorScheme) {
+function InfoRow({ label, value, placeholder, theme }: { label: string; value: string; placeholder: string; theme: any }) {
+	const hasValue = value.trim().length > 0;
+	return (
+		<View style={infoRowStyles.container}>
+			<ThemedText style={infoRowStyles.label}>{label}</ThemedText>
+			<ThemedText style={[infoRowStyles.value, !hasValue && { color: '#999', fontStyle: 'italic' }]}>
+				{hasValue ? value : placeholder}
+			</ThemedText>
+		</View>
+	);
+}
+
+const infoRowStyles = StyleSheet.create({
+	container: {
+		paddingVertical: 14,
+		paddingHorizontal: 16,
+	},
+	label: {
+		fontSize: 13,
+		color: '#888',
+		marginBottom: 4,
+		textTransform: 'uppercase',
+		letterSpacing: 0.5,
+	},
+	value: {
+		fontSize: 16,
+	},
+});
+
+function createStyles(theme: typeof Colors.light, colorScheme: 'light' | 'dark' | null | undefined) {
 	return StyleSheet.create({
 		container: {
 			padding: 24,
 		},
+		infoSection: {
+			borderRadius: 12,
+			backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : theme.background,
+			borderColor: colorScheme === 'dark' ? '#333' : '#ccc',
+			borderWidth: 1,
+			overflow: 'hidden',
+			marginBottom: 8,
+		},
 		buttonContainer: {
+			marginTop: 16,
 			marginBottom: 32,
 		},
 		sectionTitle: {

--- a/apps/mobile/app/account/subscreens/notifications.tsx
+++ b/apps/mobile/app/account/subscreens/notifications.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useState } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, SafeAreaView, ScrollView, TouchableOpacity, View, Switch } from 'react-native';
+import { useNavigation } from 'expo-router';
+import { Appearance } from 'react-native';
+import { Colors } from '@/constants/Colors';
+import { ThemedText } from '@/components/ThemedText';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'notificationSettings';
+
+export default function NotificationsScreen() {
+  const navigation = useNavigation();
+  const colorScheme = Appearance.getColorScheme();
+  const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
+  const styles = createStyles(theme, colorScheme);
+
+  const [settings, setSettings] = useState({
+    all: true,
+    messages: true,
+    bookings: true,
+    reminders: true,
+    payments: true,
+    promotions: false,
+    updates: true,
+  });
+
+  useEffect(() => {
+    navigation.setOptions({ title: 'Notifications' });
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    try {
+      const stored = await AsyncStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setSettings(JSON.parse(stored));
+      }
+    } catch (error) {
+      console.error('Failed to load notification settings:', error);
+    }
+  };
+
+  const persistSettings = async (next: typeof settings) => {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch (error) {
+      console.error('Failed to save notification settings:', error);
+    }
+  };
+
+  const toggle = (key: keyof typeof settings) => {
+    setSettings(prev => {
+      const next = { ...prev };
+
+      if (key === 'all') {
+        const activeCount = Object.entries(next)
+          .filter(([k]) => k !== 'all')
+          .filter(([_, v]) => v === true).length;
+        const totalCount = Object.keys(next).length - 1;
+        const currentState =
+          activeCount === 0 ? 'off' : activeCount === totalCount ? 'on' : 'mixed';
+        const newValue = currentState === 'on' ? false : true;
+        Object.keys(next).forEach(k => {
+          next[k as keyof typeof settings] = newValue;
+        });
+      } else {
+        next[key] = !prev[key];
+        const allOn = Object.entries(next)
+          .filter(([k]) => k !== 'all')
+          .every(([, v]) => v === true);
+        next.all = allOn;
+      }
+
+      persistSettings(next);
+      return next;
+    });
+  };
+
+  const getAllState = (): 'on' | 'off' | 'mixed' => {
+    const activeCount = Object.entries(settings)
+      .filter(([k]) => k !== 'all')
+      .filter(([_, v]) => v === true).length;
+    const totalCount = Object.keys(settings).length - 1;
+    if (activeCount === 0) return 'off';
+    if (activeCount === totalCount) return 'on';
+    return 'mixed';
+  };
+
+  const allState = getAllState();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView style={styles.scrollContent}>
+        {/* ── Master toggle ──────────────────────────────── */}
+        <View style={styles.card}>
+          <TouchableOpacity style={styles.masterRow} onPress={() => toggle('all')}>
+            <Ionicons
+              name={
+                allState === 'on'
+                  ? 'notifications'
+                  : allState === 'off'
+                    ? 'notifications-off-outline'
+                    : 'filter'
+              }
+              size={24}
+              color={allState === 'off' ? '#666' : '#e1a100'}
+              style={styles.rowIcon}
+            />
+            <View style={styles.rowText}>
+              <ThemedText type="defaultSemiBold">All Notifications</ThemedText>
+              <ThemedText style={styles.description}>
+                {allState === 'on'
+                  ? 'All notifications are enabled'
+                  : allState === 'off'
+                    ? 'All notifications are disabled'
+                    : 'Some notifications are enabled'}
+              </ThemedText>
+            </View>
+            {allState === 'mixed' ? (
+              <View style={styles.mixedIndicator}>
+                <Ionicons name="notifications" size={24} color="#0A58A5" />
+              </View>
+            ) : (
+              <Switch
+                value={allState === 'on'}
+                onValueChange={() => toggle('all')}
+                trackColor={{ false: colorScheme === 'dark' ? '#444' : '#d9d9d9', true: '#0A58A5' }}
+                thumbColor="#fff"
+              />
+            )}
+          </TouchableOpacity>
+        </View>
+
+        {/* ── Individual toggles ─────────────────────────── */}
+        <View style={styles.card}>
+          <NotificationRow
+            icon="chatbubble-ellipses-outline"
+            title="New Messages"
+            description="Get notified when you receive new messages"
+            isEnabled={settings.messages}
+            onToggle={() => toggle('messages')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+          <View style={styles.divider} />
+          <NotificationRow
+            icon="calendar-outline"
+            title="Booking Updates"
+            description="Status changes for your bookings"
+            isEnabled={settings.bookings}
+            onToggle={() => toggle('bookings')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+          <View style={styles.divider} />
+          <NotificationRow
+            icon="alarm-outline"
+            title="Appointment Reminders"
+            description="Reminders before your scheduled appointments"
+            isEnabled={settings.reminders}
+            onToggle={() => toggle('reminders')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+          <View style={styles.divider} />
+          <NotificationRow
+            icon="wallet-outline"
+            title="Payment Confirmations"
+            description="Receive updates on payment status"
+            isEnabled={settings.payments}
+            onToggle={() => toggle('payments')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+          <View style={styles.divider} />
+          <NotificationRow
+            icon="gift-outline"
+            title="Offers & Promotions"
+            description="News about discounts and special offers"
+            isEnabled={settings.promotions}
+            onToggle={() => toggle('promotions')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+          <View style={styles.divider} />
+          <NotificationRow
+            icon="information-circle-outline"
+            title="Service Updates"
+            description="Important updates about LaZone platform"
+            isEnabled={settings.updates}
+            onToggle={() => toggle('updates')}
+            colorScheme={colorScheme}
+            styles={styles}
+          />
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ─── Sub-component ───────────────────────────────────────────────────────────
+
+function NotificationRow({
+  icon,
+  title,
+  description,
+  isEnabled,
+  onToggle,
+  colorScheme,
+  styles,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  isEnabled: boolean;
+  onToggle: () => void;
+  colorScheme: string | null | undefined;
+  styles: any;
+}) {
+  return (
+    <View style={styles.row}>
+      <Ionicons
+        name={icon as any}
+        size={24}
+        color={isEnabled ? '#e1a100' : '#666'}
+        style={styles.rowIcon}
+      />
+      <View style={styles.rowText}>
+        <ThemedText type="defaultSemiBold">{title}</ThemedText>
+        <ThemedText style={styles.description}>{description}</ThemedText>
+      </View>
+      <Switch
+        value={isEnabled}
+        onValueChange={onToggle}
+        trackColor={{ false: colorScheme === 'dark' ? '#444' : '#d9d9d9', true: '#0A58A5' }}
+        thumbColor="#fff"
+      />
+    </View>
+  );
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefined) {
+  const cardBg = colorScheme === 'dark' ? '#1c1c1e' : theme.background;
+
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    scrollContent: {
+      padding: 16,
+    },
+    card: {
+      backgroundColor: cardBg,
+      borderRadius: 12,
+      paddingHorizontal: 16,
+      paddingVertical: 8,
+      marginBottom: 16,
+    },
+    masterRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: 12,
+    },
+    rowIcon: {
+      marginRight: 16,
+      width: 24,
+    },
+    rowText: {
+      flex: 1,
+    },
+    description: {
+      opacity: 0.6,
+      fontSize: 12,
+      marginTop: 2,
+    },
+    divider: {
+      height: 0.5,
+      backgroundColor: colorScheme === 'dark' ? '#444' : '#E0E0E0',
+      marginLeft: 40,
+    },
+    mixedIndicator: {
+      backgroundColor: 'rgba(10, 88, 165, 0.15)',
+      borderRadius: 16,
+      padding: 4,
+    },
+  });
+}

--- a/apps/mobile/app/account/subscreens/placeholder.tsx
+++ b/apps/mobile/app/account/subscreens/placeholder.tsx
@@ -1,0 +1,63 @@
+import { SafeAreaView, StyleSheet } from 'react-native';
+import { useLocalSearchParams, useNavigation } from 'expo-router';
+import { useEffect } from 'react';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { Ionicons } from '@expo/vector-icons';
+import { Appearance } from 'react-native';
+import { Colors } from '@/constants/Colors';
+
+/**
+ * Generic placeholder screen for routes that are planned but not yet implemented.
+ * Navigate here with: router.push({ pathname: '/account/subscreens/placeholder', params: { title: 'Page Name' } })
+ */
+export default function PlaceholderScreen() {
+  const params = useLocalSearchParams<{ title?: string }>();
+  const navigation = useNavigation();
+  const colorScheme = Appearance.getColorScheme();
+  const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
+
+  const title = params.title ?? 'Coming Soon';
+
+  useEffect(() => {
+    navigation.setOptions({ title });
+  }, [title]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ThemedView style={styles.container}>
+        <Ionicons name="construct-outline" size={56} color={theme.icon} style={styles.icon} />
+        <ThemedText type="subtitle" style={styles.title}>
+          {title}
+        </ThemedText>
+        <ThemedText style={styles.subtitle}>
+          This feature is under construction. Check back soon!
+        </ThemedText>
+      </ThemedView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 32,
+  },
+  icon: {
+    marginBottom: 16,
+  },
+  title: {
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    textAlign: 'center',
+    opacity: 0.6,
+    lineHeight: 22,
+  },
+});

--- a/apps/mobile/app/account/subscreens/preferences.tsx
+++ b/apps/mobile/app/account/subscreens/preferences.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Ionicons } from '@expo/vector-icons';
-import { StyleSheet, SafeAreaView, ScrollView, TouchableOpacity, View, Switch, Text } from 'react-native';
+import { StyleSheet, SafeAreaView, ScrollView, TouchableOpacity, View, Text } from 'react-native';
 import { Stack, useRouter, useNavigation } from 'expo-router';
 import { Appearance } from 'react-native';
 import { Colors } from '@/constants/Colors';
@@ -10,9 +10,8 @@ import { BottomPopup } from '@/components/account/BottomPopup';
 import { ThemedText } from '@/components/ThemedText';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// Contains the Notifications, Languages, and Appearance preference settings.
-// All of these three components are inside a BottomPopup and becomes visible on click. 
-// So the code is long but does similar things three times. 
+// Contains the Languages and Appearance preference settings.
+// Both are inside a BottomPopup and become visible on click.
 
 export default function PreferencesScreen() {
   const router = useRouter();
@@ -21,17 +20,6 @@ export default function PreferencesScreen() {
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
   const styles = createStyles(theme, colorScheme);
 
-  // Notifications Preference state variables
-  const [notificationPopupVisible, setNotificationPopupVisible] = useState(false);
-  const [notificationSettings, setNotificationSettings] = useState({
-    all: true,
-    messages: true,
-    bookings: true,
-    reminders: true,
-    payments: true,
-    promotions: false,
-    updates: true
-  });
   // Language setting state
   const [languagePopupVisible, setLanguagePopupVisible] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<'en' | 'fr'>('en');
@@ -39,74 +27,9 @@ export default function PreferencesScreen() {
   const [appearancePopupVisible, setAppearancePopupVisible] = useState(false);
   const [selectedAppearance, setSelectedAppearance] = useState<'light' | 'dark' | 'system'>('system');
 
-  // Toggle handler for notification switches
-  const toggleNotification = (key: keyof typeof notificationSettings) => {
-    setNotificationSettings(prev => {
-      const newSettings = { ...prev };
-
-      // Toggling All on/off
-      if (key === 'all') {
-        const activeCount = Object.entries(newSettings)
-          .filter(([k]) => k !== 'all')
-          .filter(([_, value]) => value === true)
-          .length;
-
-        const totalCount = Object.keys(newSettings).length - 1;
-        const currentState =
-          activeCount === 0 ? 'off' :
-            activeCount === totalCount ? 'on' :
-              'mixed';
-
-        const newValue = currentState === 'on' ? false : true;
-
-        // Apply the new value to all settings
-        Object.keys(newSettings).forEach(k => {
-          newSettings[k as keyof typeof notificationSettings] = newValue;
-        });
-
-        return newSettings;
-      }
-
-      // Toggle just this one switch
-      newSettings[key] = !prev[key];
-
-      // Check if all individual settings are now ON
-      const allIndividualsOn = Object.entries(newSettings)
-        .filter(([k]) => k !== 'all')
-        .every(([, value]) => value === true);
-
-      if (allIndividualsOn) {
-        // If all individual switches are ON, set "all" to ON
-        newSettings.all = true;
-      } else {
-        // If any individual switch is OFF, set "all" to OFF
-        newSettings.all = false;
-      }
-
-      return newSettings;
-    });
-  };
-
-  const getAllNotificationsState = () => {
-    const activeCount = Object.entries(notificationSettings)
-      .filter(([key]) => key !== 'all')
-      .filter(([_, value]) => value === true)
-      .length;
-    console.log("activeCount " + activeCount)
-
-    const totalCount = Object.keys(notificationSettings).length - 1; // Exclude 'all switch'
-
-    console.log("totalCount " + totalCount)
-    if (activeCount === 0) return 'off';
-    if (activeCount === totalCount) return 'on';
-    return 'mixed';
-  };
-
   useEffect(() => {
     navigation.setOptions({ title: 'Preferences' });
-    // The actual loading of the language
-    // should happen somewhere else, before the app even launches at all
-    // This is just to set what the user will see in preferences.
+
     const loadLanguage = async () => {
       try {
         const storedLanguage = await AsyncStorage.getItem('userLanguage');
@@ -119,6 +42,7 @@ export default function PreferencesScreen() {
     };
 
     loadLanguage();
+
     const loadAppearance = async () => {
       try {
         const storedAppearance = await AsyncStorage.getItem('userAppearance');
@@ -134,24 +58,16 @@ export default function PreferencesScreen() {
   }, []);
 
   const navigateTo = (route: string) => {
-    if (route === '/preferences/notifications') {
-      setNotificationPopupVisible(true);
-    } else if (route === '/preferences/language') {
+    if (route === '/preferences/language') {
       setLanguagePopupVisible(true);
     } else if (route === '/preferences/appearance') {
       setAppearancePopupVisible(true);
     } else {
-      router.push(route);
+      router.push(route as any);
     }
   };
 
   const preferenceItems: MenuItem[] = [
-    {
-      id: 'notifications',
-      label: 'Notifications',
-      icon: 'notifications-outline',
-      route: '/preferences/notifications',
-    },
     {
       id: 'language',
       label: 'Language',
@@ -175,106 +91,6 @@ export default function PreferencesScreen() {
           styles={styles}
         />
       </ScrollView>
-      <BottomPopup
-        visible={notificationPopupVisible}
-        onClose={() => setNotificationPopupVisible(false)}
-        title="Notification Preferences"
-      >
-        <View style={styles.notificationContainer}>
-          {/* Three-state master toggle */}
-          <View style={styles.notificationRow}>
-            <AllNotificationsToggle
-              state={getAllNotificationsState()}
-              onToggle={() => toggleNotification('all')}
-              styles={styles}
-            />
-          </View>
-
-          <View style={styles.divider} />
-
-          {/* Individual notification settings */}
-          <NotificationToggle
-            icon="chatbubble-ellipses-outline"
-            title="New Messages"
-            description="Get notified when you receive new messages"
-            isEnabled={notificationSettings.messages}
-            onToggle={() => toggleNotification('messages')}
-            indented
-            styles={styles}
-          />
-
-          <View style={styles.divider} />
-
-          <NotificationToggle
-            icon="calendar-outline"
-            title="Booking Updates"
-            description="Status changes for your bookings"
-            isEnabled={notificationSettings.bookings}
-            onToggle={() => toggleNotification('bookings')}
-            indented
-            styles={styles}
-          />
-
-          <View style={styles.divider} />
-
-          <NotificationToggle
-            icon="alarm-outline"
-            title="Appointment Reminders"
-            description="Reminders before your scheduled appointments"
-            isEnabled={notificationSettings.reminders}
-            onToggle={() => toggleNotification('reminders')}
-            indented
-            styles={styles}
-          />
-
-          <View style={styles.divider} />
-
-          <NotificationToggle
-            icon="wallet-outline"
-            title="Payment Confirmations"
-            description="Receive updates on payment status"
-            isEnabled={notificationSettings.payments}
-            onToggle={() => toggleNotification('payments')}
-            indented
-            styles={styles}
-          />
-
-          <View style={styles.divider} />
-
-          <NotificationToggle
-            icon="gift-outline"
-            title="Offers & Promotions"
-            description="News about discounts and special offers"
-            isEnabled={notificationSettings.promotions}
-            onToggle={() => toggleNotification('promotions')}
-            indented
-            styles={styles}
-          />
-
-          <View style={styles.divider} />
-
-          <NotificationToggle
-            icon="information-circle-outline"
-            title="Service Updates"
-            description="Important updates about LaZone platform"
-            isEnabled={notificationSettings.updates}
-            onToggle={() => toggleNotification('updates')}
-            indented
-            styles={styles}
-          />
-
-          <TouchableOpacity
-            style={styles.saveButton}
-            onPress={() => {
-              // Save notifications state before dismissing the bottom popup
-              setNotificationPopupVisible(false);
-            }}
-          >
-            <ThemedText style={styles.saveButtonText}>Save Preferences</ThemedText>
-          </TouchableOpacity>
-        </View>
-      </BottomPopup>
-
 
       {/* Language Selection Popup */}
       <BottomPopup
@@ -456,129 +272,7 @@ export default function PreferencesScreen() {
     </SafeAreaView>
   );
 }
-function NotificationToggle({
-  icon,
-  title,
-  description,
-  isEnabled,
-  onToggle,
-  indented = false,
-  styles,
-}: {
-  icon: string;
-  title: string;
-  description: string;
-  isEnabled: boolean;
-  onToggle: () => void;
-  indented?: boolean;
-  styles?: any;
-}) {
-  const colorScheme = Appearance.getColorScheme();
 
-  return (
-    <View style={[
-      styles.notificationRow,
-      indented && styles.indentedRow
-    ]}>
-      <Ionicons
-        name={icon}
-        size={24}
-        color={isEnabled ? "#e1a100" : "#666"}
-        style={styles.notificationIcon}
-      />
-      <View style={styles.notificationText}>
-        <ThemedText type="defaultSemiBold">
-          {title}
-        </ThemedText>
-        <ThemedText style={styles.notificationDescription}>
-          {description}
-        </ThemedText>
-      </View>
-      <Switch
-        value={isEnabled}
-        onValueChange={onToggle}
-        trackColor={{
-          false: colorScheme === 'dark' ? '#444' : '#d9d9d9',
-          true: '#0A58A5'
-        }}
-        thumbColor="#fff"
-      />
-    </View>
-  );
-}
-
-
-function AllNotificationsToggle({
-  state,
-  onToggle,
-  styles
-}: {
-  state: 'on' | 'off' | 'mixed',
-  onToggle: () => void,
-  styles: any
-}) {
-  const colorScheme = Appearance.getColorScheme();
-  let iconName: string;
-  let iconColor: string;
-
-  switch (state) {
-    case 'on':
-      iconName = 'notifications';
-      iconColor = "#e1a100";
-      break;
-    case 'off':
-      iconName = 'notifications-off-outline';
-      iconColor = "#666";
-      break;
-    case 'mixed':
-      iconName = 'filter';
-      iconColor = "#e1a100";
-      break;
-  }
-
-  return (
-    <TouchableOpacity
-      style={styles.allNotificationsRow}
-      onPress={onToggle}
-    >
-      <Ionicons
-        name={iconName}
-        size={24}
-        color={iconColor}
-        style={styles.notificationIcon}
-      />
-      <View style={styles.notificationText}>
-        <ThemedText type="defaultSemiBold">
-          All Notifications
-        </ThemedText>
-        <ThemedText style={styles.notificationDescription}>
-          {state === 'on' ? 'All notifications are enabled' :
-            state === 'off' ? 'All notifications are disabled' :
-              'Turn on All Notifications'}
-        </ThemedText>
-      </View>
-
-      {/* Visual indicator for the three states */}
-      <View style={styles.stateIndicator}>
-        {state === 'mixed' ? (
-          <View style={styles.mixedStateIndicator}>
-            <Ionicons name="notifications" size={24} color="#0A58A5" />
-          </View>
-        ) : (
-          <Switch
-            value={state === 'on'}
-            onValueChange={onToggle}
-            trackColor={{
-              false: colorScheme === 'dark' ? '#444' : '#d9d9d9',
-              true: '#0A58A5'
-            }}
-            thumbColor="#fff"
-          />
-        )}
-      </View>
-    </TouchableOpacity>
-  );
-}
 function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefined) {
   return StyleSheet.create({
     container: {
@@ -623,33 +317,11 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
       marginLeft: 36,
       marginRight: 25,
     },
-    // Notification styles
-    notificationContainer: {
+    // Language selection styles
+    languageContainer: {
       padding: 10,
       marginBottom: 30,
     },
-    notificationRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      marginVertical: 10,
-    },
-    indentedRow: {
-      paddingLeft: 40,
-    },
-    notificationIcon: {
-      marginRight: 16,
-      marginTop: 2,
-      width: 24,
-    },
-    notificationText: {
-      flex: 1,
-    },
-    notificationDescription: {
-      opacity: 0.7,
-      fontSize: 12,
-      marginTop: 2,
-    },
-
     saveButton: {
       backgroundColor: '#0A58A5',
       padding: 14,
@@ -660,28 +332,6 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
     saveButtonText: {
       color: '#fff',
       fontWeight: '600',
-    },
-    allNotificationsRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      marginVertical: 10,
-      padding: 5,
-      borderRadius: 8,
-    },
-    stateIndicator: {
-      alignItems: 'center',
-      justifyContent: 'center',
-      width: 50,
-    },
-    mixedStateIndicator: {
-      backgroundColor: 'rgba(10, 88, 165, 0.15)',
-      borderRadius: 16,
-      padding: 4,
-    },
-    // Language selection styles
-    languageContainer: {
-      padding: 10,
-      marginBottom: 30,
     },
     languageDescription: {
       fontSize: 14,

--- a/apps/mobile/backend/main/src/services/authService.ts
+++ b/apps/mobile/backend/main/src/services/authService.ts
@@ -7,6 +7,7 @@ import {
 import {
   doc,
   setDoc,
+  updateDoc,
   serverTimestamp,
   getDoc,
   Timestamp,
@@ -97,4 +98,18 @@ export async function getUserProfile(userId: string): Promise<User | null> {
     } as User;
   }
   return null;
+}
+
+/**
+ * Updates user profile fields in Firestore
+ */
+export async function updateUserProfile(
+  userId: string,
+  data: { firstName?: string; lastName?: string; phoneNumber?: string }
+): Promise<void> {
+  const userDocRef = doc(db, COLLECTIONS.USERS, userId);
+  await updateDoc(userDocRef, {
+    ...data,
+    updatedAt: serverTimestamp(),
+  });
 }

--- a/apps/mobile/components/account/BottomPopup.tsx
+++ b/apps/mobile/components/account/BottomPopup.tsx
@@ -5,7 +5,9 @@ import {
     StyleSheet,
     Animated,
     TouchableWithoutFeedback,
-    Dimensions
+    Dimensions,
+    KeyboardAvoidingView,
+    Platform
 } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { Ionicons } from '@expo/vector-icons';
@@ -56,6 +58,10 @@ export function BottomPopup({ visible, onClose, title, children }: Props) {
             animationType='slide'
             onRequestClose={onClose}
         >
+            <KeyboardAvoidingView
+                style={{ flex: 1 }}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            >
             <View style={styles.container}>
                 <TouchableWithoutFeedback onPress={onClose}>
                     <View style={styles.overlay} />
@@ -79,6 +85,7 @@ export function BottomPopup({ visible, onClose, title, children }: Props) {
                     </View>
                 </Animated.View>
             </View>
+            </KeyboardAvoidingView>
         </Modal>
     );
 }

--- a/apps/mobile/components/account/EditInfoPopup.tsx
+++ b/apps/mobile/components/account/EditInfoPopup.tsx
@@ -1,0 +1,136 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, Alert, ActivityIndicator, Appearance, ScrollView } from 'react-native';
+import { BottomPopup } from './BottomPopup';
+import EditableField from './EditableField';
+import { Button } from '@lazone/ui';
+import { Colors } from '@/constants/Colors';
+import { useAuth } from '@/contexts/auth';
+
+type Props = {
+	visible: boolean;
+	onClose: () => void;
+	initialData: {
+		firstName: string;
+		lastName: string;
+		email: string;
+		phone: string;
+	};
+};
+
+export default function EditInfoPopup({ visible, onClose, initialData }: Props) {
+	const [firstName, setFirstName] = useState(initialData.firstName);
+	const [lastName, setLastName] = useState(initialData.lastName);
+	const [email, setEmail] = useState(initialData.email);
+	const [phone, setPhone] = useState(initialData.phone);
+	const [saving, setSaving] = useState(false);
+
+	const { updateProfile } = useAuth();
+	const colorScheme = Appearance.getColorScheme();
+	const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
+
+	// Reset form when popup opens with fresh data
+	useEffect(() => {
+		if (visible) {
+			setFirstName(initialData.firstName);
+			setLastName(initialData.lastName);
+			setEmail(initialData.email);
+			setPhone(initialData.phone);
+		}
+	}, [visible]);
+
+	const handleSave = () => {
+		if (!firstName.trim() || !lastName.trim()) {
+			Alert.alert('Missing Info', 'First name and last name are required.');
+			return;
+		}
+
+		Alert.alert(
+			'Confirm Changes',
+			'Are you sure you want to update your information?',
+			[
+				{ text: 'Cancel', style: 'cancel' },
+				{
+					text: 'Update',
+					onPress: async () => {
+						setSaving(true);
+						try {
+							await updateProfile({
+								firstName: firstName.trim(),
+								lastName: lastName.trim(),
+								phoneNumber: phone.trim(),
+							});
+							Alert.alert('Success', 'Your information has been updated.');
+							onClose();
+						} catch (err) {
+							Alert.alert('Error', 'Could not save your info. Please try again.');
+						}
+						setSaving(false);
+					},
+				},
+			]
+		);
+	};
+
+	return (
+		<BottomPopup visible={visible} onClose={onClose} title="Edit Information">
+			<ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+					<EditableField
+						label="First Name"
+						value={firstName}
+						onChangeText={setFirstName}
+						placeholder="Enter your first name"
+					/>
+					<EditableField
+						label="Last Name"
+						value={lastName}
+						onChangeText={setLastName}
+						placeholder="Enter your last name"
+					/>
+					<EditableField
+						label="Email"
+						value={email}
+						onChangeText={setEmail}
+						keyboardType="email-address"
+						placeholder="Enter your email address"
+						autoCapitalize="none"
+					/>
+					<EditableField
+						label="Phone"
+						value={phone}
+						onChangeText={setPhone}
+						keyboardType="phone-pad"
+						placeholder="Enter your phone number"
+					/>
+
+					<View style={styles.buttonContainer}>
+						{saving ? (
+							<ActivityIndicator size="large" color={theme.tint} />
+						) : (
+							<View style={styles.buttonRow}>
+								<View style={styles.buttonWrapper}>
+									<Button label="Cancel" onPress={onClose} variant="secondary" />
+								</View>
+								<View style={styles.buttonWrapper}>
+									<Button label="Save" onPress={handleSave} variant="primary" />
+								</View>
+							</View>
+						)}
+					</View>
+			</ScrollView>
+		</BottomPopup>
+	);
+}
+
+const styles = StyleSheet.create({
+	buttonContainer: {
+		marginTop: 8,
+		marginBottom: 16,
+	},
+	buttonRow: {
+		flexDirection: 'row',
+		gap: 12,
+	},
+	buttonWrapper: {
+		flex: 1,
+	},
+});

--- a/apps/mobile/components/account/EditableField.tsx
+++ b/apps/mobile/components/account/EditableField.tsx
@@ -13,7 +13,7 @@ type Props = TextInputProps & {
 export default function EditableField({ label, value, onChangeText, ...props }: Props) {
   const colorScheme = Appearance.getColorScheme();
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
-  const styles = createStyles(theme);
+  const styles = createStyles(theme, colorScheme);
   return (
     <View style={styles.field}>
       {label && <Text style={styles.label}>{label}</Text>}
@@ -21,31 +21,35 @@ export default function EditableField({ label, value, onChangeText, ...props }: 
         value={value}
         onChangeText={onChangeText}
         style={styles.input}
-        placeholderTextColor="#888"
+        placeholderTextColor="#999"
         {...props}
       />
     </View>
   );
 }
 
-function createStyles(theme) {
+function createStyles(theme: typeof Colors.light, colorScheme: 'light' | 'dark' | null | undefined) {
   return StyleSheet.create({
     field: {
       marginBottom: 16,
       width: '100%',
     },
     label: {
-      color: theme.text,
-      marginBottom: 4,
-      fontSize: 16,
+      color: '#888',
+      marginBottom: 6,
+      fontSize: 13,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
     },
     input: {
-      borderRadius: 20,
+      borderRadius: 10,
       paddingVertical: 12,
-      paddingHorizontal: 16,
+      paddingHorizontal: 14,
       color: theme.text,
       fontSize: 16,
-      backgroundColor: theme.background,
+      backgroundColor: colorScheme === 'dark' ? '#2c2c2e' : '#f2f2f7',
+      borderWidth: 1,
+      borderColor: colorScheme === 'dark' ? '#444' : '#d1d1d6',
     },
   });
 }

--- a/apps/mobile/components/ui/IconSymbol.tsx
+++ b/apps/mobile/components/ui/IconSymbol.tsx
@@ -22,6 +22,8 @@ const MAPPING = {
   'calendar': 'event',
   'message': 'message',
   'person.fill': 'person',
+  'briefcase': 'business-center',
+  'briefcase.fill': 'business-center',
 } as IconMapping;
 
 /**

--- a/apps/mobile/constants/account.ts
+++ b/apps/mobile/constants/account.ts
@@ -19,84 +19,67 @@ export const MOCK_USER_PROFILE: UserProfile = {
     updatedAt: '2024-01-01T00:00:00Z',
 };
 
-export const ACCOUNT_MENU_ITEMS: Record<string, MenuItem[]> = {
-    requester: [
-    {
-        id: 'saved',
-        label: 'Saved Providers',
-        route: '/account/subscreens/savedproviders',
-        icon: 'bookmark-outline',
-    },
-    {
-        id: 'wallet',
-        label: 'Wallet',
-        route: '/account/subscreens/wallet',
-        icon: 'wallet-outline',
-    },
-    {
-        id: 'invite',
-        label: 'Invite friends',
-        route: '/invite',
-        icon: 'share-social-outline',
-    },
-    ],
-    provider: [
-    {
-        id: 'my-portfolio',
-        label: 'preview/edit portfolio',
-        route: `/provider/preview?id=${MOCK_USER_PROFILE.id}`, // Add providerId
-        icon: 'briefcase-outline',
-    },
-    {
-        id: 'earnings',
-        label: 'Earnings',
-        route: '/earnings',
-        icon: 'cash-outline',
-    },
-    {
-        id: 'reviews',
-        label: 'Reviews',
-        route: `/provider/reviews?id=${MOCK_USER_PROFILE.id}`, // Add providerId to reviews route
-        icon: 'star-outline',
-    },
-    {
-        id: 'invite',
-        label: 'Invite friends',
-        route: '/invite',
-        icon: 'share-social-outline',
-    },
-    ],
-    settings: [
-    {
-        id: 'preferences',
-        label: 'Preferences',
-        route: '/account/subscreens/preferences',
-        icon: 'settings-outline',
-    },
-    {
-        id: 'account',
-        label: 'Account Info',
-        route: '/account/info',
-        icon: 'person-outline',
-    },
-    ],
-    resources: [
-    {
-        id: 'become-provider',
-        label: 'Become a Provider',
-        route: '/provider/registration',
-        icon: 'briefcase-outline',
-        roleAccess: ['requester'],
-    },
-    {
-        id: 'terms',
-        label: 'Terms and Policies',
-        route: '/terms',
-        icon: 'document-text-outline',
-    },
+// ── Unified Profile menu items (no role separation) ──────────────────────────
+// Role-conditional items use the `roleAccess` field and are filtered at render time.
+
+export const PROFILE_MENU_ITEMS: Record<string, MenuItem[]> = {
+    /** Shown to everyone */
+    general: [
+        {
+            id: 'saved',
+            label: 'Saved Businesses',
+            route: '/account/subscreens/savedproviders',
+            icon: 'bookmark-outline',
+        },
+        {
+            id: 'wallet',
+            label: 'Payment Methods',
+            route: '/account/subscreens/wallet',
+            icon: 'wallet-outline',
+        },
+        {
+            id: 'invite',
+            label: 'Invite Friends',
+            route: '/account/subscreens/placeholder?title=Invite%20Friends',
+            icon: 'share-social-outline',
+        },
     ],
 
+    /** Settings — shown to everyone */
+    settings: [
+        {
+            id: 'preferences',
+            label: 'Preferences',
+            route: '/account/subscreens/preferences',
+            icon: 'settings-outline',
+        },
+        {
+            id: 'notifications',
+            label: 'Notification Settings',
+            route: '/account/subscreens/notifications',
+            icon: 'notifications-outline',
+        },
+    ],
+
+    /** Support — shown to everyone */
+    support: [
+        {
+            id: 'help',
+            label: 'Help & Support',
+            route: '/account/subscreens/placeholder?title=Help%20%26%20Support',
+            icon: 'help-circle-outline',
+        },
+        {
+            id: 'terms',
+            label: 'Terms and Policies',
+            route: '/account/subscreens/placeholder?title=Terms%20and%20Policies',
+            icon: 'document-text-outline',
+        },
+    ],
 };
+
+// Keep the old export name as an alias so nothing else breaks during migration.
+export const ACCOUNT_MENU_ITEMS = PROFILE_MENU_ITEMS;
 export const WALLET_SETTINGS_ITEMS: Record<string,  MenuItem[]> = {
     settings: [
         {

--- a/apps/mobile/contexts/auth.tsx
+++ b/apps/mobile/contexts/auth.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { onAuthStateChanged, User as FirebaseUser } from 'firebase/auth';
 import { auth } from '../backend/main/src/config/firebase';
-import { signupUser, loginUser, logoutUser, getUserProfile } from '../backend/main/src/services/authService';
+import { signupUser, loginUser, logoutUser, getUserProfile, updateUserProfile } from '../backend/main/src/services/authService';
 import { User as AppUser } from '../backend/main/src/models/User';
 
 interface AuthContextType {
@@ -9,10 +9,11 @@ interface AuthContextType {
   userProfile: AppUser | null;
   isAuthenticated: boolean;
   loading: boolean;
-  signup: (fullName, email, password, phone) => Promise<void>;
-  login: (email, password) => Promise<void>;
+  signup: (fullName: string, email: string, password: string, phone: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
-  refreshUserProfile: () => Promise<void>; // Add a refresh function for debugging
+  refreshUserProfile: () => Promise<void>;
+  updateProfile: (data: { firstName?: string; lastName?: string; phoneNumber?: string }) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -59,7 +60,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   // Wrapper for the login function to also set the profile state.
-  const handleLogin = async (email, password) => {
+  const handleLogin = async (email: string, password: string) => {
     const firebaseUser = await loginUser(email, password);
     const profile = await getUserProfile(firebaseUser.uid);
     setUser(firebaseUser);
@@ -67,7 +68,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   // Wrapper for the signup function to set state from the returned data.
-  const handleSignup = async (fullName, email, password, phone) => {
+  const handleSignup = async (fullName: string, email: string, password: string, phone: string) => {
     const { firebaseUser, profile } = await signupUser(fullName, email, password, phone);
     setUser(firebaseUser);
     setUserProfile(profile);
@@ -80,6 +81,16 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setUserProfile(null);
   };
 
+  // Wrapper for updating user profile fields in Firestore.
+  const handleUpdateProfile = async (data: { firstName?: string; lastName?: string; phoneNumber?: string }) => {
+    const currentUser = auth.currentUser;
+    if (!currentUser) throw new Error('No authenticated user');
+    await updateUserProfile(currentUser.uid, data);
+    // Refresh the local profile state after update
+    const profile = await getUserProfile(currentUser.uid);
+    setUserProfile(profile);
+  };
+
   const value = {
     user,
     userProfile,
@@ -88,7 +99,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     signup: handleSignup,
     login: handleLogin,
     logout: handleLogout,
-    refreshUserProfile, // Expose the refresh function
+    refreshUserProfile,
+    updateProfile: handleUpdateProfile,
   };
 
   return (


### PR DESCRIPTION
- Add Business tab (provider-only)
- Redesign Account screen as unified Profile with business visibility toggle and "Become a Provider"
- Extract notification settings from preferences popup into standalone screen
- Add placeholder screen for unbuilt routes
- Update icon mappings for briefcase symbol


No major new code. Just move  screens around according to what we discussed. 

Everything inside Business screen is static placeholder that will be later. 