### PR TITLE
Wire business screen to real booking data with accept/decline flow 

### DIFF
--- a/apps/mobile/app/(tabs)/booked.tsx
+++ b/apps/mobile/app/(tabs)/booked.tsx
@@ -1,7 +1,7 @@
-import { SafeAreaView, ScrollView, StyleSheet, RefreshControl, ActivityIndicator, View, Appearance } from 'react-native';
+import { SafeAreaView, ScrollView, StyleSheet, RefreshControl, ActivityIndicator, View, Appearance, TouchableOpacity } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useFocusEffect } from '@react-navigation/native';
-import { useCallback } from 'react';
+import { useCallback, useState, useMemo } from 'react';
 import { ThemedText } from '@/components/ThemedText';
 import { BookingCard } from '@/components/booking/BookingCard';
 import { useBookings } from '@/hooks/useBookings';
@@ -9,6 +9,9 @@ import { useAuth } from '@/contexts/auth';
 import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@lazone/ui';
 import { Colors } from '@/constants/Colors';
+import { BookingViewModel } from '@/types/booking';
+
+type BookingFilter = 'active' | 'completed' | 'cancelled';
 
 export default function BookedScreen() {
   const router = useRouter();
@@ -16,6 +19,7 @@ export default function BookedScreen() {
   const { bookings, isLoading, refreshBookings } = useBookings(user?.uid);
   const colorScheme = Appearance.getColorScheme();
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
+  const [activeFilter, setActiveFilter] = useState<BookingFilter>('active');
 
   // Auto-refresh every time the tab comes into focus
   useFocusEffect(
@@ -25,6 +29,46 @@ export default function BookedScreen() {
       }
     }, [user?.uid, refreshBookings])
   );
+
+  // Partition bookings by filter category
+  const activeBookings = useMemo(
+    () => bookings.filter((b) => b.status === 'pending' || b.status === 'confirmed' || b.status === 'in_progress'),
+    [bookings]
+  );
+  const completedBookings = useMemo(
+    () => bookings.filter((b) => b.status === 'completed'),
+    [bookings]
+  );
+  const cancelledBookings = useMemo(
+    () => bookings.filter((b) => b.status === 'cancelled'),
+    [bookings]
+  );
+
+  const filteredBookings: BookingViewModel[] =
+    activeFilter === 'active' ? activeBookings
+    : activeFilter === 'completed' ? completedBookings
+    : cancelledBookings;
+
+  const filters: { id: BookingFilter; label: string; count: number }[] = [
+    { id: 'active', label: 'Active', count: activeBookings.length },
+    { id: 'completed', label: 'Completed', count: completedBookings.length },
+    { id: 'cancelled', label: 'Cancelled', count: cancelledBookings.length },
+  ];
+
+  const emptyMessages: Record<BookingFilter, { title: string; subtitle: string }> = {
+    active: {
+      title: 'No active bookings',
+      subtitle: 'Browse providers and book a service to get started.',
+    },
+    completed: {
+      title: 'No completed bookings',
+      subtitle: 'Your finished bookings will appear here.',
+    },
+    cancelled: {
+      title: 'No cancelled bookings',
+      subtitle: 'Cancelled bookings will appear here.',
+    },
+  };
 
   if (isLoading && bookings.length === 0) {
     return (
@@ -40,13 +84,55 @@ export default function BookedScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <ScrollView
-        contentContainerStyle={bookings.length === 0 ? styles.emptyContainer : styles.content}
+        contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl refreshing={isLoading} onRefresh={refreshBookings} />
         }
       >
         <ThemedText type="title" style={styles.title}>My Bookings</ThemedText>
 
+        {/* ── Filter Tabs ──────────────────────────────── */}
+        {bookings.length > 0 && (
+          <View style={styles.filterRow}>
+            {filters.map((filter) => {
+              const isActive = activeFilter === filter.id;
+              return (
+                <TouchableOpacity
+                  key={filter.id}
+                  style={[
+                    styles.filterTab,
+                    isActive && styles.activeFilterTab,
+                    colorScheme === 'dark' && !isActive && styles.filterTabDark,
+                  ]}
+                  onPress={() => setActiveFilter(filter.id)}
+                  activeOpacity={0.7}
+                >
+                  <ThemedText style={[
+                    styles.filterTabText,
+                    isActive && styles.activeFilterTabText,
+                  ]}>
+                    {filter.label}
+                  </ThemedText>
+                  {filter.count > 0 && (
+                    <View style={[
+                      styles.filterBadge,
+                      isActive && styles.activeFilterBadge,
+                    ]}>
+                      <ThemedText style={[
+                        styles.filterBadgeText,
+                        isActive && styles.activeFilterBadgeText,
+                      ]}>
+                        {filter.count}
+                      </ThemedText>
+                    </View>
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+        )}
+
+        {/* ── Booking List ─────────────────────────────── */}
         {bookings.length === 0 ? (
           <View style={styles.emptyState}>
             <Ionicons name="calendar-outline" size={64} color={theme.icon} />
@@ -61,8 +147,18 @@ export default function BookedScreen() {
               style={styles.emptyButton}
             />
           </View>
+        ) : filteredBookings.length === 0 ? (
+          <View style={styles.emptyFilterState}>
+            <Ionicons
+              name={activeFilter === 'completed' ? 'checkmark-circle-outline' : activeFilter === 'cancelled' ? 'close-circle-outline' : 'calendar-outline'}
+              size={48}
+              color={theme.icon}
+            />
+            <ThemedText style={styles.emptyTitle}>{emptyMessages[activeFilter].title}</ThemedText>
+            <ThemedText style={styles.emptySubtitle}>{emptyMessages[activeFilter].subtitle}</ThemedText>
+          </View>
         ) : (
-          bookings.map((booking) => (
+          filteredBookings.map((booking) => (
             <BookingCard
               key={booking.id}
               booking={booking}
@@ -83,12 +179,8 @@ const styles = StyleSheet.create({
     padding: 20,
     flexGrow: 1,
   },
-  emptyContainer: {
-    padding: 20,
-    flexGrow: 1,
-  },
   title: {
-    marginBottom: 20,
+    marginBottom: 16,
   },
   centered: {
     flex: 1,
@@ -100,10 +192,69 @@ const styles = StyleSheet.create({
     fontSize: 16,
     opacity: 0.7,
   },
+
+  // ── Filter tabs ──
+  filterRow: {
+    flexDirection: 'row',
+    marginBottom: 20,
+    gap: 8,
+  },
+  filterTab: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+    gap: 6,
+  },
+  filterTabDark: {
+    borderColor: '#444',
+  },
+  activeFilterTab: {
+    backgroundColor: '#0A58A5',
+    borderColor: '#0A58A5',
+  },
+  filterTabText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  activeFilterTabText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  filterBadge: {
+    backgroundColor: '#E0E0E0',
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 6,
+  },
+  activeFilterBadge: {
+    backgroundColor: 'rgba(255, 255, 255, 0.25)',
+  },
+  filterBadgeText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#555',
+  },
+  activeFilterBadgeText: {
+    color: '#fff',
+  },
+
+  // ── Empty states ──
   emptyState: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  emptyFilterState: {
+    alignItems: 'center',
+    paddingVertical: 48,
     paddingHorizontal: 32,
   },
   emptyTitle: {

--- a/apps/mobile/app/(tabs)/business.tsx
+++ b/apps/mobile/app/(tabs)/business.tsx
@@ -5,78 +5,22 @@ import {
   ScrollView,
   TouchableOpacity,
   Appearance,
-  Image,
+  RefreshControl,
+  ActivityIndicator,
+  Alert,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { useCallback, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useAuth } from '@/contexts/auth';
+import { useProviderBookings } from '@/hooks/useBookings';
 import { Ionicons } from '@expo/vector-icons';
 import { Button } from '@lazone/ui';
-
-// ─── Static Data (to be replaced with hooks / Firestore later) ───────────────
-
-const STATS = {
-  profileViews: 128,
-  totalEarnings: '475,000 CFA',
-  averageRating: 4.7,
-  completedJobs: 34,
-};
-
-const INCOMING_REQUESTS = [
-  {
-    id: 'req-1',
-    clientName: 'Aminata Ouédraogo',
-    clientAvatar: null,
-    serviceName: 'Kitchen Plumbing Repair',
-    requestedDate: '2026-02-20T10:00:00',
-    message: 'My kitchen sink has been leaking for a couple days. Available Friday morning.',
-    createdAt: '2026-02-17T08:30:00',
-  },
-  {
-    id: 'req-2',
-    clientName: 'Moussa Traoré',
-    clientAvatar: null,
-    serviceName: 'Bathroom Tiling',
-    requestedDate: '2026-02-22T14:00:00',
-    message: 'Need the bathroom floor re-tiled. About 8 m².',
-    createdAt: '2026-02-16T19:45:00',
-  },
-];
-
-const UPCOMING_BOOKINGS = [
-  {
-    id: 'bk-1',
-    clientName: 'Fatou Compaoré',
-    serviceName: 'Electrical Wiring',
-    scheduledDate: '2026-02-19T09:00:00',
-    status: 'confirmed' as const,
-    price: '120,000 CFA',
-  },
-  {
-    id: 'bk-2',
-    clientName: 'Ibrahim Kaboré',
-    serviceName: 'Light Fixture Installation',
-    scheduledDate: '2026-02-21T15:30:00',
-    status: 'confirmed' as const,
-    price: '45,000 CFA',
-  },
-  {
-    id: 'bk-3',
-    clientName: 'Awa Sané',
-    serviceName: 'Full Apartment Rewiring',
-    scheduledDate: '2026-02-25T08:00:00',
-    status: 'confirmed' as const,
-    price: '310,000 CFA',
-  },
-];
-
-const RECENT_EARNINGS = [
-  { id: 'e-1', clientName: 'Jean-Paul Nikiéma', service: 'Outlet Repair', amount: '35,000 CFA', date: '2026-02-15' },
-  { id: 'e-2', clientName: 'Mariam Sawadogo', service: 'Generator Hookup', amount: '90,000 CFA', date: '2026-02-12' },
-  { id: 'e-3', clientName: 'David Zoungrana', service: 'Panel Upgrade', amount: '150,000 CFA', date: '2026-02-08' },
-];
+import Toast from '@/components/ui/Toast';
+import { useToast } from '@/hooks/useToast';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -100,16 +44,85 @@ function timeAgo(isoString: string) {
   return `${days}d ago`;
 }
 
+function formatPrice(amount: number): string {
+  return amount.toLocaleString('en-US') + ' CFA';
+}
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function BusinessScreen() {
   const router = useRouter();
-  const { userProfile } = useAuth();
+  const { user, userProfile } = useAuth();
   const colorScheme = Appearance.getColorScheme();
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
   const styles = createStyles(theme, colorScheme);
+  const { toast, showToast, hideToast } = useToast();
 
   const isProvider = userProfile?.role === 'provider' || userProfile?.role === 'both';
+
+  // Provider's booking data — providerId === user._id
+  const {
+    incomingRequests,
+    upcomingBookings,
+    completedBookings,
+    acceptBooking,
+    declineBooking,
+    isLoading,
+    refreshBookings,
+  } = useProviderBookings(isProvider ? user?.uid : undefined);
+
+  // Track which booking is currently being acted on (for button loading states)
+  const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+
+  // Refresh bookings whenever this tab comes into focus
+  useFocusEffect(
+    useCallback(() => {
+      if (isProvider && user?.uid) {
+        refreshBookings();
+      }
+    }, [isProvider, user?.uid, refreshBookings])
+  );
+
+  // ── Computed metrics ──
+  const totalEarnings = completedBookings.reduce((sum, b) => sum + b.price, 0);
+
+  // ── Handlers ──
+  const handleAccept = async (bookingId: string) => {
+    setActionInFlight(bookingId);
+    try {
+      await acceptBooking(bookingId);
+      showToast('Booking accepted', 'success');
+    } catch {
+      showToast('Failed to accept booking', 'error');
+    } finally {
+      setActionInFlight(null);
+    }
+  };
+
+  const handleDecline = (bookingId: string, clientName: string) => {
+    Alert.alert(
+      'Decline Request',
+      `Are you sure you want to decline the request from ${clientName}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Decline',
+          style: 'destructive',
+          onPress: async () => {
+            setActionInFlight(bookingId);
+            try {
+              await declineBooking(bookingId);
+              showToast('Request declined', 'success');
+            } catch {
+              showToast('Failed to decline request', 'error');
+            } finally {
+              setActionInFlight(null);
+            }
+          },
+        },
+      ]
+    );
+  };
 
   // Non-provider users see a prompt to register
   if (!isProvider) {
@@ -135,7 +148,13 @@ export default function BusinessScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.scrollContent} showsVerticalScrollIndicator={false}>
+      <ScrollView
+        style={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl refreshing={isLoading} onRefresh={refreshBookings} />
+        }
+      >
         {/* ── Header ────────────────────────────────────── */}
         <View style={styles.titleRow}>
           <ThemedText type="title" style={styles.title}>Business</ThemedText>
@@ -149,28 +168,28 @@ export default function BusinessScreen() {
           <MetricCard
             icon="eye-outline"
             label="Profile Views"
-            value={String(STATS.profileViews)}
+            value="—"
             theme={theme}
             colorScheme={colorScheme}
           />
           <MetricCard
             icon="cash-outline"
             label="Earnings"
-            value={STATS.totalEarnings}
+            value={formatPrice(totalEarnings)}
             theme={theme}
             colorScheme={colorScheme}
           />
           <MetricCard
             icon="star-outline"
             label="Avg Rating"
-            value={String(STATS.averageRating)}
+            value="—"
             theme={theme}
             colorScheme={colorScheme}
           />
           <MetricCard
             icon="checkmark-done-outline"
             label="Completed"
-            value={String(STATS.completedJobs)}
+            value={String(completedBookings.length)}
             theme={theme}
             colorScheme={colorScheme}
           />
@@ -179,17 +198,21 @@ export default function BusinessScreen() {
         {/* ── Incoming Requests ──────────────────────────── */}
         <SectionHeader
           title="Incoming Requests"
-          count={INCOMING_REQUESTS.length}
+          count={incomingRequests.length}
           theme={theme}
         />
-        {INCOMING_REQUESTS.length === 0 ? (
+        {incomingRequests.length === 0 ? (
           <ThemedView style={styles.emptyCard}>
             <ThemedText style={styles.emptyText}>No pending requests</ThemedText>
           </ThemedView>
         ) : (
-          INCOMING_REQUESTS.map((req) => (
-            <ThemedView
+          incomingRequests.map((req) => (
+            <TouchableOpacity
               key={req.id}
+              activeOpacity={0.7}
+              onPress={() => router.push(`/booking/${req.id}?role=provider`)}
+            >
+            <ThemedView
               style={styles.requestCard}
               lightColor={theme.background}
               darkColor="#1c1c1e"
@@ -200,96 +223,139 @@ export default function BusinessScreen() {
                     <Ionicons name="person" size={18} color="#fff" />
                   </View>
                   <View style={{ flex: 1 }}>
-                    <ThemedText type="defaultSemiBold">{req.clientName}</ThemedText>
+                    <ThemedText type="defaultSemiBold">{req.requesterName}</ThemedText>
                     <ThemedText style={styles.requestService}>{req.serviceName}</ThemedText>
                   </View>
                   <ThemedText style={styles.timeAgo}>{timeAgo(req.createdAt)}</ThemedText>
                 </View>
               </View>
-              <ThemedText style={styles.requestMessage} numberOfLines={2}>
-                "{req.message}"
-              </ThemedText>
+              {req.notes ? (
+                <ThemedText style={styles.requestMessage} numberOfLines={2}>
+                  "{req.notes}"
+                </ThemedText>
+              ) : null}
               <View style={styles.requestMeta}>
                 <View style={styles.requestDateRow}>
                   <Ionicons name="calendar-outline" size={14} color={theme.icon} />
                   <ThemedText style={styles.requestDateText}>
-                    {formatDate(req.requestedDate)} at {formatTime(req.requestedDate)}
+                    {formatDate(req.bookingDate)} at {formatTime(req.bookingDate)}
                   </ThemedText>
                 </View>
+                <ThemedText style={styles.requestPrice}>{formatPrice(req.price)}</ThemedText>
               </View>
               <View style={styles.requestActions}>
-                <TouchableOpacity style={styles.declineButton}>
-                  <ThemedText style={styles.declineText}>Decline</ThemedText>
+                <TouchableOpacity
+                  style={styles.declineButton}
+                  onPress={() => handleDecline(req.id, req.requesterName)}
+                  disabled={actionInFlight === req.id}
+                >
+                  {actionInFlight === req.id ? (
+                    <ActivityIndicator size="small" color={theme.text} />
+                  ) : (
+                    <ThemedText style={styles.declineText}>Decline</ThemedText>
+                  )}
                 </TouchableOpacity>
-                <TouchableOpacity style={styles.acceptButton}>
-                  <ThemedText style={styles.acceptText}>Accept</ThemedText>
+                <TouchableOpacity
+                  style={styles.acceptButton}
+                  onPress={() => handleAccept(req.id)}
+                  disabled={actionInFlight === req.id}
+                >
+                  {actionInFlight === req.id ? (
+                    <ActivityIndicator size="small" color="#fff" />
+                  ) : (
+                    <ThemedText style={styles.acceptText}>Accept</ThemedText>
+                  )}
                 </TouchableOpacity>
               </View>
             </ThemedView>
+            </TouchableOpacity>
           ))
         )}
 
         {/* ── Upcoming Bookings ──────────────────────────── */}
         <SectionHeader
           title="Upcoming Bookings"
-          count={UPCOMING_BOOKINGS.length}
+          count={upcomingBookings.length}
           theme={theme}
         />
-        {UPCOMING_BOOKINGS.map((booking) => (
-          <ThemedView
-            key={booking.id}
-            style={styles.bookingCard}
-            lightColor={theme.background}
-            darkColor="#1c1c1e"
-          >
-            <View style={styles.bookingRow}>
-              <View style={{ flex: 1 }}>
-                <ThemedText type="defaultSemiBold">{booking.clientName}</ThemedText>
-                <ThemedText style={styles.bookingService}>{booking.serviceName}</ThemedText>
-                <View style={styles.bookingDateRow}>
-                  <Ionicons name="calendar-outline" size={14} color={theme.icon} />
-                  <ThemedText style={styles.bookingDateText}>
-                    {formatDate(booking.scheduledDate)} at {formatTime(booking.scheduledDate)}
+        {upcomingBookings.length === 0 ? (
+          <ThemedView style={styles.emptyCard}>
+            <ThemedText style={styles.emptyText}>No upcoming bookings</ThemedText>
+          </ThemedView>
+        ) : (
+          upcomingBookings.map((booking) => (
+            <TouchableOpacity
+              key={booking.id}
+              activeOpacity={0.7}
+              onPress={() => router.push(`/booking/${booking.id}?role=provider`)}
+            >
+            <ThemedView
+              style={styles.bookingCard}
+              lightColor={theme.background}
+              darkColor="#1c1c1e"
+            >
+              <View style={styles.bookingRow}>
+                <View style={{ flex: 1 }}>
+                  <ThemedText type="defaultSemiBold">{booking.requesterName}</ThemedText>
+                  <ThemedText style={styles.bookingService}>{booking.serviceName}</ThemedText>
+                  <View style={styles.bookingDateRow}>
+                    <Ionicons name="calendar-outline" size={14} color={theme.icon} />
+                    <ThemedText style={styles.bookingDateText}>
+                      {formatDate(booking.bookingDate)} at {formatTime(booking.bookingDate)}
+                    </ThemedText>
+                  </View>
+                </View>
+                <View style={styles.bookingRight}>
+                  <ThemedText type="defaultSemiBold" style={styles.bookingPrice}>
+                    {formatPrice(booking.price)}
                   </ThemedText>
-                </View>
-              </View>
-              <View style={styles.bookingRight}>
-                <ThemedText type="defaultSemiBold" style={styles.bookingPrice}>
-                  {booking.price}
-                </ThemedText>
-                <View style={styles.confirmedBadge}>
-                  <ThemedText style={styles.confirmedText}>Confirmed</ThemedText>
-                </View>
+                  <View style={styles.confirmedBadge}>
+                    <ThemedText style={styles.confirmedText}>
+                      {booking.status === 'in_progress' ? 'In Progress' : 'Confirmed'}
+                    </ThemedText>
+                  </View>
               </View>
             </View>
           </ThemedView>
-        ))}
+          </TouchableOpacity>
+          ))
+        )}
 
         {/* ── Recent Earnings ────────────────────────────── */}
         <SectionHeader title="Recent Earnings" theme={theme} />
-        <ThemedView
-          style={styles.earningsCard}
-          lightColor={theme.background}
-          darkColor="#1c1c1e"
-        >
-          {RECENT_EARNINGS.map((earning, index) => (
-            <View key={earning.id}>
-              <View style={styles.earningRow}>
-                <View style={{ flex: 1 }}>
-                  <ThemedText type="defaultSemiBold">{earning.service}</ThemedText>
-                  <ThemedText style={styles.earningClient}>{earning.clientName}</ThemedText>
+        {completedBookings.length === 0 ? (
+          <ThemedView style={styles.emptyCard}>
+            <ThemedText style={styles.emptyText}>No completed bookings yet</ThemedText>
+          </ThemedView>
+        ) : (
+          <ThemedView
+            style={styles.earningsCard}
+            lightColor={theme.background}
+            darkColor="#1c1c1e"
+          >
+            {completedBookings.map((booking, index) => (
+              <TouchableOpacity
+                key={booking.id}
+                activeOpacity={0.7}
+                onPress={() => router.push(`/booking/${booking.id}?role=provider`)}
+              >
+                <View style={styles.earningRow}>
+                  <View style={{ flex: 1 }}>
+                    <ThemedText type="defaultSemiBold">{booking.serviceName}</ThemedText>
+                    <ThemedText style={styles.earningClient}>{booking.requesterName}</ThemedText>
+                  </View>
+                  <View style={styles.earningRight}>
+                    <ThemedText type="defaultSemiBold" style={styles.earningAmount}>
+                      {formatPrice(booking.price)}
+                    </ThemedText>
+                    <ThemedText style={styles.earningDate}>{formatDate(booking.bookingDate)}</ThemedText>
+                  </View>
                 </View>
-                <View style={styles.earningRight}>
-                  <ThemedText type="defaultSemiBold" style={styles.earningAmount}>
-                    {earning.amount}
-                  </ThemedText>
-                  <ThemedText style={styles.earningDate}>{formatDate(earning.date)}</ThemedText>
-                </View>
-              </View>
-              {index < RECENT_EARNINGS.length - 1 && <View style={styles.divider} />}
-            </View>
-          ))}
-        </ThemedView>
+                {index < completedBookings.length - 1 && <View style={styles.divider} />}
+              </TouchableOpacity>
+            ))}
+          </ThemedView>
+        )}
 
         {/* ── Quick Actions ──────────────────────────────── */}
         <SectionHeader title="Manage" theme={theme} />
@@ -327,6 +393,14 @@ export default function BusinessScreen() {
         {/* Bottom spacing for tab bar */}
         <View style={{ height: 32 }} />
       </ScrollView>
+
+      {/* ── Toast notifications ──────────────────────── */}
+      <Toast
+        visible={toast.visible}
+        message={toast.message}
+        type={toast.type}
+        onDismiss={hideToast}
+      />
     </SafeAreaView>
   );
 }
@@ -554,6 +628,9 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
     },
     requestMeta: {
       marginBottom: 12,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
     },
     requestDateRow: {
       flexDirection: 'row',
@@ -563,6 +640,11 @@ function createStyles(theme: any, colorScheme: 'dark' | 'light' | null | undefin
     requestDateText: {
       fontSize: 13,
       opacity: 0.6,
+    },
+    requestPrice: {
+      fontSize: 14,
+      fontWeight: '600',
+      color: '#0A58A5',
     },
     requestActions: {
       flexDirection: 'row',

--- a/apps/mobile/app/booking/[id].tsx
+++ b/apps/mobile/app/booking/[id].tsx
@@ -4,11 +4,12 @@ import { useFocusEffect } from '@react-navigation/native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useBookingDetail } from '@/hooks/useBookings';
+import * as bookingRepo from '@/repositories/bookingRepository';
 import { Button } from '@lazone/ui';
 import { Ionicons } from '@expo/vector-icons';
 import { getStatusColor } from '@/components/booking/BookingStatus';
 import { BookingStatus, BookingViewModel } from '@/types/booking';
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { Colors } from '@/constants/Colors';
 import Toast from '@/components/ui/Toast';
 import { useToast } from '@/hooks/useToast';
@@ -23,10 +24,12 @@ function formatStatus(status: BookingStatus): string {
 }
 
 export default function BookingDetailsScreen() {
-  const { id } = useLocalSearchParams();
+  const { id, role } = useLocalSearchParams();
   const bookingId = id?.toString();
+  const isProvider = role === 'provider';
   const { booking, isLoading, cancelBooking, refreshBooking } = useBookingDetail(bookingId);
   const { toast, showToast, hideToast } = useToast();
+  const [actionInFlight, setActionInFlight] = useState(false);
   const colorScheme = Appearance.getColorScheme() || 'light';
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
 
@@ -114,6 +117,47 @@ export default function BookingDetailsScreen() {
     });
   };
 
+  const handleAcceptBooking = async () => {
+    if (!bookingId) return;
+    setActionInFlight(true);
+    try {
+      await bookingRepo.confirmBooking(bookingId);
+      showToast('Booking accepted', 'success');
+      refreshBooking();
+    } catch {
+      showToast('Failed to accept booking', 'error');
+    } finally {
+      setActionInFlight(false);
+    }
+  };
+
+  const handleDeclineBooking = () => {
+    if (!bookingId || !booking) return;
+    Alert.alert(
+      'Decline Request',
+      `Are you sure you want to decline this request from ${booking.requesterName}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Decline',
+          style: 'destructive',
+          onPress: async () => {
+            setActionInFlight(true);
+            try {
+              await bookingRepo.declineBooking(bookingId);
+              showToast('Request declined', 'success');
+              refreshBooking();
+            } catch {
+              showToast('Failed to decline request', 'error');
+            } finally {
+              setActionInFlight(false);
+            }
+          },
+        },
+      ]
+    );
+  };
+
   // Loading state
   if (isLoading) {
     return (
@@ -137,6 +181,31 @@ export default function BookingDetailsScreen() {
   const statusColor = getStatusColor(booking.status);
 
   const renderActionButtons = () => {
+    if (isProvider) {
+      return (
+        <View style={styles.bottomButtons}>
+          {booking.status === 'pending' && (
+            <>
+              <Button
+                label={actionInFlight ? 'Accepting...' : 'Accept Booking'}
+                onPress={handleAcceptBooking}
+                variant="success"
+                style={styles.actionButton}
+                disabled={actionInFlight}
+              />
+              <Button
+                label={actionInFlight ? 'Declining...' : 'Decline'}
+                onPress={handleDeclineBooking}
+                variant="secondary"
+                style={styles.cancelButton}
+                disabled={actionInFlight}
+              />
+            </>
+          )}
+        </View>
+      );
+    }
+
     return (
       <View style={styles.bottomButtons}>
         {booking.status === 'pending' && (
@@ -210,30 +279,47 @@ export default function BookingDetailsScreen() {
           </ThemedView>
         </View>
 
-        {/* Provider Section */}
+        {/* Person Section — Provider sees client info, Requester sees provider info */}
         <View style={styles.section}>
-          <ThemedText type="subtitle">Provider Information</ThemedText>
+          <ThemedText type="subtitle">
+            {isProvider ? 'Client Information' : 'Provider Information'}
+          </ThemedText>
           <ThemedView style={[styles.card, { backgroundColor: colorScheme === 'dark' ? '#1c1c1e' : '#f5f5f5' }]}>
             <View style={styles.providerInfo}>
               <Ionicons name="person-circle-outline" size={40} color="#666" />
-              <ThemedText style={styles.providerName}>{booking.providerName}</ThemedText>
+              <ThemedText style={styles.providerName}>
+                {isProvider ? booking.requesterName : booking.providerName}
+              </ThemedText>
             </View>
-            <View style={styles.buttonContainer}>
-              <Button
-                label="View Profile"
-                onPress={() => router.push(`/provider/${booking.providerId}`)}
-                variant="primary"
-                size="small"
-                style={styles.providerButton}
-              />
-              <Button
-                label="Message"
-                onPress={() => {}}
-                variant="primary"
-                size="small"
-                style={styles.providerButton}
-              />
-            </View>
+            {!isProvider && (
+              <View style={styles.buttonContainer}>
+                <Button
+                  label="View Profile"
+                  onPress={() => router.push(`/provider/${booking.providerId}`)}
+                  variant="primary"
+                  size="small"
+                  style={styles.providerButton}
+                />
+                <Button
+                  label="Message"
+                  onPress={() => {}}
+                  variant="primary"
+                  size="small"
+                  style={styles.providerButton}
+                />
+              </View>
+            )}
+            {isProvider && (booking.status === 'confirmed' || booking.status === 'in_progress' || booking.status === 'completed') && (
+              <View style={styles.buttonContainer}>
+                <Button
+                  label="Message"
+                  onPress={() => {}}
+                  variant="primary"
+                  size="small"
+                  style={styles.providerButton}
+                />
+              </View>
+            )}
           </ThemedView>
         </View>
 

--- a/apps/mobile/hooks/useBookings.ts
+++ b/apps/mobile/hooks/useBookings.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { BookingViewModel, CreateBookingInput, UpdateBookingInput } from '@/types/booking';
 import * as bookingRepo from '@/repositories/bookingRepository';
 
@@ -198,3 +198,151 @@ export function useBookingDetail(bookingId?: string): UseBookingDetailResult {
     refreshBooking,
   };
 }
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Provider-side hook — "Bookings others made TO me"
+// Separate from useBookings (requester-side) by design:
+//   • Different Firestore query (providerId vs requesterId)
+//   • Different mutations (accept/decline vs create/cancel/edit)
+//   • Different UI filtering (pending → incoming, confirmed → upcoming, etc.)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+export interface UseProviderBookingsResult {
+  /** All bookings for this provider (unfiltered) */
+  allBookings: BookingViewModel[];
+  /** Pending bookings awaiting provider response */
+  incomingRequests: BookingViewModel[];
+  /** Confirmed or in-progress bookings */
+  upcomingBookings: BookingViewModel[];
+  /** Completed bookings (for earnings display) */
+  completedBookings: BookingViewModel[];
+
+  /** Transition a pending booking → confirmed */
+  acceptBooking: (bookingId: string) => Promise<void>;
+  /** Transition a pending booking → cancelled (declined) */
+  declineBooking: (bookingId: string) => Promise<void>;
+
+  isLoading: boolean;
+  error: Error | null;
+  refreshBookings: () => Promise<void>;
+}
+
+/**
+ * Hook for the provider's Business screen.
+ * Fetches all bookings where the current user is the provider,
+ * then partitions them by status for different UI sections.
+ *
+ * @param providerId — The provider's ID (same as user._id for providers)
+ */
+export function useProviderBookings(providerId?: string): UseProviderBookingsResult {
+  const [allBookings, setAllBookings] = useState<BookingViewModel[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchBookings = useCallback(async () => {
+    if (!providerId) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await bookingRepo.getProviderBookings(providerId);
+      setAllBookings(data);
+    } catch (err) {
+      console.error('[useProviderBookings] Error fetching bookings:', err);
+      setError(err instanceof Error ? err : new Error('Failed to fetch provider bookings'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [providerId]);
+
+  useEffect(() => {
+    fetchBookings();
+  }, [fetchBookings]);
+
+  // ── Derived lists (re-computed only when allBookings changes) ──
+
+  const incomingRequests = useMemo(
+    () => allBookings.filter((b) => b.status === 'pending'),
+    [allBookings]
+  );
+
+  const upcomingBookings = useMemo(
+    () => allBookings.filter((b) => b.status === 'confirmed' || b.status === 'in_progress'),
+    [allBookings]
+  );
+
+  const completedBookings = useMemo(
+    () => allBookings.filter((b) => b.status === 'completed'),
+    [allBookings]
+  );
+
+  // ── Mutations with optimistic updates ──
+
+  const acceptBooking = useCallback(
+    async (bookingId: string): Promise<void> => {
+      const previous = [...allBookings];
+
+      // Optimistic: move from pending → confirmed
+      setAllBookings((prev) =>
+        prev.map((b) =>
+          b.id === bookingId ? { ...b, status: 'confirmed' as const } : b
+        )
+      );
+
+      try {
+        await bookingRepo.confirmBooking(bookingId);
+        console.log('[useProviderBookings] Booking accepted:', bookingId);
+      } catch (err) {
+        console.error('[useProviderBookings] Error accepting booking:', err);
+        setAllBookings(previous); // Rollback
+        const error = err instanceof Error ? err : new Error('Failed to accept booking');
+        setError(error);
+        throw error;
+      }
+    },
+    [allBookings]
+  );
+
+  const declineBooking = useCallback(
+    async (bookingId: string): Promise<void> => {
+      const previous = [...allBookings];
+
+      // Optimistic: move from pending → cancelled
+      setAllBookings((prev) =>
+        prev.map((b) =>
+          b.id === bookingId ? { ...b, status: 'cancelled' as const } : b
+        )
+      );
+
+      try {
+        await bookingRepo.declineBooking(bookingId);
+        console.log('[useProviderBookings] Booking declined:', bookingId);
+      } catch (err) {
+        console.error('[useProviderBookings] Error declining booking:', err);
+        setAllBookings(previous); // Rollback
+        const error = err instanceof Error ? err : new Error('Failed to decline booking');
+        setError(error);
+        throw error;
+      }
+    },
+    [allBookings]
+  );
+
+  const refreshBookings = useCallback(async () => {
+    await fetchBookings();
+  }, [fetchBookings]);
+
+  return {
+    allBookings,
+    incomingRequests,
+    upcomingBookings,
+    completedBookings,
+    acceptBooking,
+    declineBooking,
+    isLoading,
+    error,
+    refreshBookings,
+  };
+}
+

--- a/apps/mobile/repositories/bookingRepository.ts
+++ b/apps/mobile/repositories/bookingRepository.ts
@@ -111,3 +111,26 @@ export async function cancelBooking(bookingId: string): Promise<void> {
   console.log('[BookingRepository] Booking cancelled successfully');
 }
 
+// ========== Provider-side Read ==========
+
+export async function getProviderBookings(providerId: string): Promise<BookingViewModel[]> {
+  console.log('[BookingRepository] Fetching bookings for provider:', providerId);
+
+  const docs = await BookingService.getBookingsByProviderId(providerId);
+  return docs.map(toViewModel);
+}
+
+// ========== Provider-side Status Mutations ==========
+
+export async function confirmBooking(bookingId: string): Promise<void> {
+  console.log('[BookingRepository] Confirming booking:', bookingId);
+  await BookingService.updateBookingStatus(bookingId, 'confirmed');
+  console.log('[BookingRepository] Booking confirmed successfully');
+}
+
+export async function declineBooking(bookingId: string): Promise<void> {
+  console.log('[BookingRepository] Declining booking:', bookingId);
+  await BookingService.updateBookingStatus(bookingId, 'cancelled');
+  console.log('[BookingRepository] Booking declined successfully');
+}
+


### PR DESCRIPTION
 wire business screen to real booking data with accept/decline flow 
- Add getProviderBookings, confirmBooking, declineBooking to bookingRepository 
- Add useProviderBookings hook (separate from requester-side useBookings) 
- Replace all static data in business screen with real Firestore bookings 
- Wire accept/decline buttons with optimistic updates, alerts, and toasts 
- Make booking detail screen role-aware (provider vs requester) 
- Provider sees Client Information instead of Provider Information 
- Provider sees Accept/Decline buttons for pending bookings 
- Provider sees Message button after accepting (confirmed/in_progress/completed) 
- Make all business screen booking cards tappable → booking detail with role=provider 
- Add pull-to-refresh and focus-refresh to business screen 
- Add filter tabs (Active/Completed/Cancelled) to user's Booked screen 
- Use success green (#56B224) for accept buttons to match app design system