### PR TITLE
Exclude provider's own profile from browse and search results

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -11,7 +11,6 @@ import { useState, useEffect, useMemo } from 'react';
 import AppHeader from '@/components/ui/AppHeader';
 import { useProvider } from '@/hooks/useProvider';
 import { useLocation } from '@/hooks/useLocation';
-import { useAuth } from '@/contexts/auth';
 
 export default function HomeScreen() {
   const colorScheme = Appearance.getColorScheme();

--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, useMemo } from 'react';
 import AppHeader from '@/components/ui/AppHeader';
 import { useProvider } from '@/hooks/useProvider';
 import { useLocation } from '@/hooks/useLocation';
+import { useAuth } from '@/contexts/auth';
 
 export default function HomeScreen() {
   const colorScheme = Appearance.getColorScheme();

--- a/apps/mobile/hooks/useProvider.ts
+++ b/apps/mobile/hooks/useProvider.ts
@@ -9,11 +9,15 @@ import {
 } from "@/repositories/providerRepository";
 import { ProviderViewModel, ProviderRegistration } from "@/types/provider";
 import { Coordinates } from "@/backend/main/src/utils/geo";
+import { useAuth } from "@/contexts/auth";
 
 /**
  * Hook Layer - State Management Wrapper for React Components
  * Uses repository methods and manages loading/error states
  * Provides convenience methods for UI interactions
+ *
+ * Automatically excludes the current user's own provider profile from all
+ * list results so a provider never sees themselves in browse/search.
  */
 
 export interface UseProviderResult {
@@ -41,6 +45,10 @@ export const useProvider = (providerId?: string): UseProviderResult => {
   const [providers, setProviders] = useState<ProviderViewModel[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
+  // Get the current user's ID to exclude their own provider profile from lists
+  const { user } = useAuth();
+  const currentUserId = user?.uid;
 
   // Fetch single provider when providerId is provided
   useEffect(() => {
@@ -71,14 +79,14 @@ export const useProvider = (providerId?: string): UseProviderResult => {
     setError(null);
 
     try {
-      const data = await getAllProvidersWithDetails(userLocation);
+      const data = await getAllProvidersWithDetails(userLocation, currentUserId);
       setProviders(data);
     } catch (err: any) {
       setError(err);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [currentUserId]);
 
   /**
    * Fetches providers by category
@@ -90,14 +98,14 @@ export const useProvider = (providerId?: string): UseProviderResult => {
     setError(null);
 
     try {
-      const data = await getProvidersByCategory(category, userLocation);
+      const data = await getProvidersByCategory(category, userLocation, currentUserId);
       setProviders(data);
     } catch (err: any) {
       setError(err);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [currentUserId]);
 
   /**
    * Searches providers with filters
@@ -108,14 +116,14 @@ export const useProvider = (providerId?: string): UseProviderResult => {
     setError(null);
 
     try {
-      const data = await repoSearchProviders(params);
+      const data = await repoSearchProviders({ ...params, excludeId: currentUserId });
       setProviders(data);
     } catch (err: any) {
       setError(err);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [currentUserId]);
 
   /**
    * Refetches the current provider data

--- a/apps/mobile/repositories/providerRepository.ts
+++ b/apps/mobile/repositories/providerRepository.ts
@@ -58,12 +58,19 @@ export async function getProviderViewModel(
 /**
  * Fetches all providers with details populated
  * @param userLocation - Optional user's current location for distance calculation
+ * @param excludeId - Optional provider ID to exclude from results (e.g., current user)
  */
 export async function getAllProvidersWithDetails(
-  userLocation?: Coordinates | null
+  userLocation?: Coordinates | null,
+  excludeId?: string
 ): Promise<ProviderViewModel[]> {
   try {
-    const providers = await ProviderService.getAllProviders();
+    let providers = await ProviderService.getAllProviders();
+
+    // Exclude the specified provider early (before expensive populate calls)
+    if (excludeId) {
+      providers = providers.filter(p => p._id !== excludeId);
+    }
 
     return await Promise.all(
       providers.map(async (provider) => {
@@ -90,13 +97,20 @@ export async function getAllProvidersWithDetails(
  * Searches providers by category with details populated
  * @param category - Category to filter by
  * @param userLocation - Optional user's current location for distance calculation
+ * @param excludeId - Optional provider ID to exclude from results (e.g., current user)
  */
 export async function getProvidersByCategory(
   category: string,
-  userLocation?: Coordinates | null
+  userLocation?: Coordinates | null,
+  excludeId?: string
 ): Promise<ProviderViewModel[]> {
   try {
-    const providers = await ProviderService.getProvidersByCategory(category);
+    let providers = await ProviderService.getProvidersByCategory(category);
+
+    // Exclude the specified provider early (before expensive populate calls)
+    if (excludeId) {
+      providers = providers.filter(p => p._id !== excludeId);
+    }
 
     return await Promise.all(
       providers.map(async (provider) => {
@@ -130,6 +144,7 @@ export interface SearchProvidersParams {
   maxPrice?: number;
   maxDistance?: number;
   userLocation?: Coordinates | null;
+  excludeId?: string; // Provider ID to exclude from results (e.g., current user)
 }
 
 /**
@@ -141,12 +156,17 @@ export async function searchProviders(
 ): Promise<ProviderViewModel[]> {
   try {
     // Use backend search for basic filtering
-    const providers = await ProviderService.searchProviders({
+    let providers = await ProviderService.searchProviders({
       query: params.query,
       category: params.category,
       remoteOnly: params.remoteOnly,
       minRating: params.minRating,
     });
+
+    // Exclude the specified provider early
+    if (params.excludeId) {
+      providers = providers.filter(p => p._id !== params.excludeId);
+    }
 
     // Transform to ViewModels with distance calculation
     const viewModels = await Promise.all(


### PR DESCRIPTION
A service provider who is logged in will no longer see themselves in the home feed, category listings, or search results. Added excludeId parameter to repository layer (getAllProvidersWithDetails, getProvidersByCategory, searchProviders) to filter out a provider before expensive populate/transform calls useProvider hook automatically reads the current user's UID from useAuth() and passes it to the repository — no consumer changes needed All screens using useProvider() get the behavior automatically