### PR TITLE
Implement end-to-end bookmark functionality with Firestore persistence

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import { useEffect } from 'react';
 import { AuthProvider, useAuth } from '@/contexts/auth';
+import { BookmarkProvider } from '@/contexts/bookmarks';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
@@ -63,10 +64,12 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <AuthProvider>
-        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-          <RootLayoutNav />
-          <StatusBar style="auto" />
-        </ThemeProvider>
+        <BookmarkProvider>
+          <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+            <RootLayoutNav />
+            <StatusBar style="auto" />
+          </ThemeProvider>
+        </BookmarkProvider>
       </AuthProvider>
     </GestureHandlerRootView>
   );

--- a/apps/mobile/app/account/subscreens/savedproviders.tsx
+++ b/apps/mobile/app/account/subscreens/savedproviders.tsx
@@ -1,21 +1,12 @@
-import { useEffect, useState } from 'react';
-import { View, StyleSheet, TouchableOpacity, Image, ScrollView, SafeAreaView } from 'react-native';
+import { useCallback } from 'react';
+import { View, StyleSheet, TouchableOpacity, Image, ScrollView, SafeAreaView, ActivityIndicator, RefreshControl } from 'react-native';
 import { Stack, useRouter, useFocusEffect } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
-import { ThemedView } from '@/components/ThemedView';
 import { Platform } from 'react-native';
 import { Colors } from '@/constants/Colors';
 import { Appearance } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
-
-type Provider = {
-    id: number;
-    name: string;
-    description: string;
-    rating: number;
-    avatar: any;
-};
+import { useBookmarks } from '@/hooks/useBookmarks';
 
 export default function SavedProvidersScreen() {
     const router = useRouter();
@@ -23,43 +14,22 @@ export default function SavedProvidersScreen() {
     const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
     const styles = createStyles(theme, colorScheme);
 
-    const [savedProviders, setSavedProviders] = useState<Provider[]>([]);
+    const {
+        bookmarkedProviders,
+        fetchBookmarkedProviders,
+        isLoadingProviders,
+        toggleBookmark,
+    } = useBookmarks();
 
-    useFocusEffect(() => {
-        loadSavedProviders();
-    });
-
-    // Normally, load saved providers from AsyncStorage
-    const loadSavedProviders = async () => {
-        try {
-            const savedData = await AsyncStorage.getItem('savedProviders');
-            if (savedData) {
-                setSavedProviders(JSON.parse(savedData));
-            } else {
-                setSavedProviders([
-                    {
-                        id: 1,
-                        name: "John's Plumbing Services",
-                        description: "Highly rated plumbing solutions for your home.",
-                        rating: 4.8,
-                        avatar: require('@/assets/images/avatar-placeholder.png'),
-                    },
-                    {
-                        id: 2,
-                        name: "Electric Solutions Co.",
-                        description: "Experienced electricians for all installations.",
-                        rating: 4.7,
-                        avatar: require('@/assets/images/avatar-placeholder.png'),
-                    },
-                ]);
-            }
-        } catch (error) {
-            console.error("Failed to load saved providers:", error);
-        }
-    };
+    // Fetch full provider details when screen comes into focus
+    useFocusEffect(
+        useCallback(() => {
+            fetchBookmarkedProviders();
+        }, [fetchBookmarkedProviders])
+    );
 
     // Navigate to a provider's profile
-    const navigateToProvider = (id: number) => {
+    const navigateToProvider = (id: string | number) => {
         router.push(`/provider/${id}`);
     };
 
@@ -75,8 +45,22 @@ export default function SavedProvidersScreen() {
                 }}
             />
 
-            <ScrollView style={styles.scrollContainer}>
-                {savedProviders.length === 0 ? (
+            <ScrollView
+                style={styles.scrollContainer}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={isLoadingProviders}
+                        onRefresh={fetchBookmarkedProviders}
+                        tintColor={theme.tint}
+                    />
+                }
+            >
+                {isLoadingProviders && bookmarkedProviders.length === 0 ? (
+                    <View style={styles.emptyState}>
+                        <ActivityIndicator size="large" color={theme.tint} />
+                        <ThemedText style={styles.emptySubtext}>Loading saved providers...</ThemedText>
+                    </View>
+                ) : bookmarkedProviders.length === 0 ? (
                     <View style={styles.emptyState}>
                         <Ionicons name="bookmark" size={48} color={theme.tabIconDefault} />
                         <ThemedText style={styles.emptyText}>
@@ -87,26 +71,41 @@ export default function SavedProvidersScreen() {
                         </ThemedText>
                     </View>
                 ) : (
-                    savedProviders.map((provider) => (
+                    bookmarkedProviders.map((provider) => (
                         <TouchableOpacity
-                            key={provider.id}
+                            key={String(provider.id)}
                             style={styles.providerCard}
-                            // No need to add unbookmark ability. User can press and unbookmark from the profider's profile and 
-                            // saved providers list will update itself and reflect back here.
                             onPress={() => navigateToProvider(provider.id)}
-
                         >
-                            <Image source={provider.avatar} style={styles.providerAvatar} />
+                            <Image
+                                source={
+                                    typeof provider.avatar === 'string'
+                                        ? { uri: provider.avatar }
+                                        : provider.avatar ?? require('@/assets/images/avatar-placeholder.png')
+                                }
+                                style={styles.providerAvatar}
+                            />
                             <View style={styles.providerInfo}>
-                                <ThemedText type="defaultSemiBold" style={styles.providerName}>
-                                    {provider.name}
-                                </ThemedText>
+                                <View style={styles.nameRow}>
+                                    <ThemedText type="defaultSemiBold" style={styles.providerName}>
+                                        {provider.name}
+                                    </ThemedText>
+                                    <TouchableOpacity
+                                        onPress={() => toggleBookmark(String(provider.id))}
+                                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                                    >
+                                        <Ionicons name="bookmark" size={22} color="#0A58A5" />
+                                    </TouchableOpacity>
+                                </View>
                                 <ThemedText style={styles.providerDescription}>
-                                    {provider.description}
+                                    {provider.profession}
                                 </ThemedText>
                                 <View style={styles.ratingContainer}>
                                     <ThemedText style={styles.ratingText}>
-                                        {provider.rating} <Ionicons name="star" size={14} color="#FFD700" />
+                                        {provider.rating.toFixed(1)} <Ionicons name="star" size={14} color="#FFD700" />
+                                    </ThemedText>
+                                    <ThemedText style={styles.reviewCount}>
+                                        ({provider.reviews} reviews)
                                     </ThemedText>
                                 </View>
                             </View>
@@ -134,7 +133,6 @@ function createStyles(theme: any, colorScheme: string | null | undefined) {
             padding: 16,
             marginBottom: 16,
             alignItems: 'center',
-            // Shadow for light mode
             ...Platform.select({
                 ios: {
                     shadowColor: '#000',
@@ -158,9 +156,16 @@ function createStyles(theme: any, colorScheme: string | null | undefined) {
         providerInfo: {
             flex: 1,
         },
+        nameRow: {
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: 4,
+        },
         providerName: {
             fontSize: 18,
-            marginBottom: 4,
+            flex: 1,
+            marginRight: 8,
         },
         providerDescription: {
             fontSize: 14,
@@ -175,6 +180,11 @@ function createStyles(theme: any, colorScheme: string | null | undefined) {
             fontSize: 14,
             color: '#FFD700',
             fontWeight: '600',
+        },
+        reviewCount: {
+            fontSize: 13,
+            opacity: 0.6,
+            marginLeft: 6,
         },
         emptyState: {
             flex: 1,

--- a/apps/mobile/app/provider/[id].tsx
+++ b/apps/mobile/app/provider/[id].tsx
@@ -12,6 +12,7 @@ import { useBookmarks } from '@/hooks/useBookmarks';
 import ReviewsComponent from '@/components/reviews/ReviewsComponent';
 import { useReviews } from '@/hooks/useReviews';
 import { useAuth } from '@/contexts/auth';
+import { requireAuth } from '@/utils/auth';
 import Toast from '@/components/ui/Toast';
 import { useToast } from '@/hooks/useToast';
 
@@ -76,6 +77,12 @@ export default function ProviderProfileScreen() {
   const { user } = useAuth();
   const currentUserId = user?.uid;
 
+  const handleBookmarkPress = async () => {
+    if (!requireAuth(currentUserId, 'Please sign in to save providers.')) return;
+    toggleBookmark(providerId);
+  };
+
+
   // Use enhanced reviews hook with user context
   const {
     reviews: reviewItems,
@@ -116,10 +123,7 @@ export default function ProviderProfileScreen() {
       return;
     }
 
-    if (!currentUserId) {
-      Alert.alert('Error', 'Please log in to submit a review');
-      return;
-    }
+    if (!requireAuth(currentUserId, 'Please sign in to submit a review.')) return;
 
     setSubmittingReview(true);
 
@@ -224,7 +228,7 @@ export default function ProviderProfileScreen() {
             <View style={styles.nameRow}>
               <ThemedText type="defaultSemiBold" style={styles.name}>{provider.name}</ThemedText>
               <TouchableOpacity 
-                onPress={() => toggleBookmark(providerId)}
+                onPress={handleBookmarkPress}
                 style={styles.bookmarkButton}
                 disabled={isLoading}
               >
@@ -245,10 +249,7 @@ export default function ProviderProfileScreen() {
           <Button
             label="Message"
             onPress={() => {
-              if (!currentUserId) {
-                Alert.alert('Sign in required', 'Please sign in to message this provider.');
-                return;
-              }
+              if (!requireAuth(currentUserId, 'Please sign in to message this provider.')) return;
               // Compute canonical conversation ID without creating a Firestore document.
               // The conversation will only be created when the first message is sent.
               const sortedIds = [currentUserId, String(provider.id)].sort();
@@ -348,10 +349,7 @@ export default function ProviderProfileScreen() {
             <View style={styles.reviewActions}>
               <TouchableOpacity
                 onPress={() => {
-                  if (!currentUserId) {
-                    Alert.alert('Sign In Required', 'Please sign in to leave a review');
-                    return;
-                  }
+                  if (!requireAuth(currentUserId, 'Please sign in to leave a review.')) return;
 
                   // TODO: Toggle this to enable/disable review eligibility check
                   // Set to `true` to enforce booking requirement, `false` to skip for testing
@@ -390,10 +388,7 @@ export default function ProviderProfileScreen() {
             currentUserId={currentUserId}
             onRespondToReview={handleRespondToReview}
             onMarkHelpful={async (reviewId) => {
-              if (!currentUserId) {
-                Alert.alert('Sign In Required', 'Please sign in to vote');
-                return;
-              }
+              if (!requireAuth(currentUserId, 'Please sign in to vote.')) return;
               try {
                 await markHelpful(reviewId);
               } catch {

--- a/apps/mobile/app/provider/reviews.tsx
+++ b/apps/mobile/app/provider/reviews.tsx
@@ -5,6 +5,7 @@ import { Colors } from '@/constants/Colors';
 import ReviewsComponent from '@/components/reviews/ReviewsComponent';
 import { useReviews } from '@/hooks/useReviews';
 import { useAuth } from '@/contexts/auth';
+import { requireAuth } from '@/utils/auth';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { Button } from '@lazone/ui';
@@ -49,10 +50,7 @@ export default function ProviderReviewsScreen() {
 
   // Handle opening review modal with validation
   const handleOpenReviewModal = () => {
-    if (!currentUserId) {
-      Alert.alert('Sign In Required', 'Please sign in to leave a review');
-      return;
-    }
+    if (!requireAuth(currentUserId, 'Please sign in to leave a review.')) return;
 
     // TODO: Toggle this to enable/disable review eligibility check
     // Set to `true` to enforce booking requirement, `false` to skip for testing
@@ -171,10 +169,7 @@ export default function ProviderReviewsScreen() {
             }
           }}
           onMarkHelpful={async (reviewId: string) => {
-            if (!currentUserId) {
-              Alert.alert('Sign In Required', 'Please sign in to vote');
-              return;
-            }
+            if (!requireAuth(currentUserId, 'Please sign in to vote.')) return;
             try {
               await markHelpful(reviewId);
             } catch {

--- a/apps/mobile/backend/main/src/models/User.ts
+++ b/apps/mobile/backend/main/src/models/User.ts
@@ -1,4 +1,4 @@
-import { Timestamp, DocumentReference } from "firebase/firestore";
+import { Timestamp } from "firebase/firestore";
 import { Location } from "./Location";
 
 export interface User {
@@ -11,7 +11,7 @@ export interface User {
   avatar?: string;
   verified: boolean;
   subscriptionType: "free" | "premium" | "enterprise";
-  bookmarked: DocumentReference[]; // References to other User documents
+  bookmarked: string[]; // Provider IDs the user has saved
   location?: Location;
   createdAt: Timestamp;
   updatedAt: Timestamp;

--- a/apps/mobile/backend/main/src/services/bookmarkService.ts
+++ b/apps/mobile/backend/main/src/services/bookmarkService.ts
@@ -1,0 +1,61 @@
+import {
+  doc,
+  getDoc,
+  updateDoc,
+  arrayUnion,
+  arrayRemove,
+} from "firebase/firestore";
+import { db, COLLECTIONS } from "../config/firebase";
+
+/**
+ * Bookmark Service — Firestore operations for user bookmarks
+ *
+ * Bookmarks are stored as a string[] on the User document: users/{userId}.bookmarked
+ * Uses arrayUnion/arrayRemove for atomic, race-condition-free toggles.
+ *
+ * Why this works well for LaZone:
+ *   - A user realistically saves 10-50 providers, not thousands
+ *   - No extra metadata needed (just provider IDs)
+ *   - One fewer collection/subcollection to manage
+ *   - The bookmarked field is already on the User model (Provider inherits it)
+ *   - arrayUnion/arrayRemove are atomic — no read-modify-write needed
+ */
+
+/**
+ * Add a provider to the user's bookmarks.
+ * Atomic — arrayUnion won't add duplicates.
+ */
+export async function addBookmark(userId: string, providerId: string): Promise<void> {
+  const userRef = doc(db, COLLECTIONS.USERS, userId);
+  await updateDoc(userRef, {
+    bookmarked: arrayUnion(providerId),
+  });
+}
+
+/**
+ * Remove a provider from the user's bookmarks.
+ * Atomic — arrayRemove is a no-op if the value doesn't exist.
+ */
+export async function removeBookmark(userId: string, providerId: string): Promise<void> {
+  const userRef = doc(db, COLLECTIONS.USERS, userId);
+  await updateDoc(userRef, {
+    bookmarked: arrayRemove(providerId),
+  });
+}
+
+/**
+ * Get all bookmarked provider IDs for a user.
+ * Reads the user document and returns the bookmarked array.
+ */
+export async function getBookmarkedProviderIds(userId: string): Promise<string[]> {
+  const userRef = doc(db, COLLECTIONS.USERS, userId);
+  const snap = await getDoc(userRef);
+
+  if (!snap.exists()) {
+    return [];
+  }
+
+  return (snap.data().bookmarked as string[]) || [];
+}
+
+

--- a/apps/mobile/components/provider/ProviderListItem.tsx
+++ b/apps/mobile/components/provider/ProviderListItem.tsx
@@ -1,9 +1,10 @@
 import { View, StyleSheet, Image, Pressable, Appearance, TouchableOpacity } from 'react-native';
-import { useState, useEffect } from 'react';
 import { Ionicons } from '@expo/vector-icons';
 import { ThemedText } from '@/components/ThemedText';
 import { Colors } from '@/constants/Colors';
 import { useBookmarks } from '@/hooks/useBookmarks';
+import { useAuth } from '@/contexts/auth';
+import { requireAuth } from '@/utils/auth';
 
 type Props = {
   id: string; // Add provider ID to props
@@ -16,9 +17,15 @@ type Props = {
 
 export default function ProviderListItem({ id, name, description, avatar, rating, onPress }: Props) {
   const { isBookmarked, toggleBookmark, isLoading } = useBookmarks();
+  const { user } = useAuth();
   const colorScheme = Appearance.getColorScheme();
   const theme = colorScheme === 'dark' ? Colors.dark : Colors.light;
   const styles = createStyles(theme, colorScheme);
+
+  const handleBookmarkPress = () => {
+    if (!requireAuth(user?.uid, 'Please sign in to save providers.')) return;
+    toggleBookmark(id);
+  };
 
 
   return (
@@ -34,7 +41,7 @@ export default function ProviderListItem({ id, name, description, avatar, rating
           <TouchableOpacity 
             onPress={(e) =>{
               e.stopPropagation(); // Prevent triggering onPress of Pressable
-              toggleBookmark(id);
+              handleBookmarkPress();
             }}
             style={styles.bookmarkButton}
             disabled={isLoading}

--- a/apps/mobile/components/reviews/ReviewsComponent.tsx
+++ b/apps/mobile/components/reviews/ReviewsComponent.tsx
@@ -6,6 +6,7 @@ import { Button } from '@lazone/ui';
 import { Ionicons } from '@expo/vector-icons';
 import { Colors } from '@/constants/Colors';
 import { Review, ReviewStats } from '@/types/provider';
+import { requireAuth } from '@/utils/auth';
 
 type ReviewsComponentProps = {
   reviews: Review[];
@@ -329,10 +330,7 @@ export default function ReviewsComponent({
                     onPress={() => {
                       // Don't allow users to vote on their own reviews
                       if (currentUserId === review.userId) return;
-                      if (!currentUserId) {
-                        Alert.alert('Sign In Required', 'Please sign in to vote');
-                        return;
-                      }
+                      if (!requireAuth(currentUserId, 'Please sign in to vote.')) return;
                       onMarkHelpful && onMarkHelpful(review.id);
                     }}
                     disabled={currentUserId === review.userId}

--- a/apps/mobile/contexts/bookmarks.tsx
+++ b/apps/mobile/contexts/bookmarks.tsx
@@ -1,0 +1,201 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from '@/contexts/auth';
+import * as bookmarkRepository from '@/repositories/bookmarkRepository';
+import { ProviderViewModel } from '@/types/provider';
+
+const BOOKMARK_CACHE_PREFIX = 'bookmark_ids_cache_';
+
+interface BookmarkContextType {
+  /** Set of bookmarked provider IDs (for fast lookups) */
+  bookmarkedIds: string[];
+  /** Check if a provider is bookmarked — O(1) via Set */
+  isBookmarked: (providerId: string) => boolean;
+  /** Toggle bookmark on/off — optimistic UI + Firestore sync */
+  toggleBookmark: (providerId: string) => Promise<boolean>;
+  /** Full provider data for the Saved Providers screen */
+  bookmarkedProviders: ProviderViewModel[];
+  /** Fetch full provider details for all bookmarks */
+  fetchBookmarkedProviders: () => Promise<void>;
+  /** Whether initial bookmark IDs are loading */
+  isLoading: boolean;
+  /** Whether full provider details are loading */
+  isLoadingProviders: boolean;
+}
+
+const BookmarkContext = createContext<BookmarkContextType | undefined>(undefined);
+
+export function useBookmarkContext() {
+  const context = useContext(BookmarkContext);
+  if (!context) {
+    throw new Error('useBookmarkContext must be used within a BookmarkProvider');
+  }
+  return context;
+}
+
+export function BookmarkProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth();
+  const userId = user?.uid ?? null;
+
+  const [bookmarkedIds, setBookmarkedIds] = useState<string[]>([]);
+  const [bookmarkedProviders, setBookmarkedProviders] = useState<ProviderViewModel[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingProviders, setIsLoadingProviders] = useState(false);
+
+  // Build a Set for O(1) lookups — memoized on the ids array
+  const bookmarkedSet = useMemo(() => new Set(bookmarkedIds), [bookmarkedIds]);
+
+  // ─── Load bookmark IDs on auth change ────────────────────────────────
+  useEffect(() => {
+    if (!userId) {
+      // User signed out — clear everything including cache
+      setBookmarkedIds([]);
+      setBookmarkedProviders([]);
+      setIsLoading(false);
+      // No userId available, so we can't build the key — cache was already
+      // written with the previous userId's key, which is fine; it will be
+      // overwritten if/when that same user logs back in.
+      return;
+    }
+
+    let cancelled = false;
+    const cacheKey = `${BOOKMARK_CACHE_PREFIX}${userId}`;
+
+    const load = async () => {
+      setIsLoading(true);
+
+      // 1. Show cached data immediately (offline-first)
+      try {
+        const cached = await AsyncStorage.getItem(cacheKey);
+        if (cached && !cancelled) {
+          setBookmarkedIds(JSON.parse(cached));
+        }
+      } catch {
+        // Cache miss is fine
+      }
+
+      // 2. Fetch fresh data from Firestore
+      try {
+        const ids = await bookmarkRepository.getBookmarkedIds(userId);
+        if (!cancelled) {
+          setBookmarkedIds(ids);
+          await AsyncStorage.setItem(cacheKey, JSON.stringify(ids));
+        }
+      } catch (error) {
+        console.error('Error loading bookmarks from Firestore:', error);
+        // Cached data (if any) remains visible
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => { cancelled = true; };
+  }, [userId]);
+
+  // ─── O(1) bookmark check ────────────────────────────────────────────
+  const isBookmarked = useCallback(
+    (providerId: string) => bookmarkedSet.has(providerId),
+    [bookmarkedSet]
+  );
+
+  // ─── Toggle with optimistic update ──────────────────────────────────
+  const toggleBookmark = useCallback(
+    async (providerId: string): Promise<boolean> => {
+      if (!userId) {
+        // Not authenticated — caller should handle auth gate
+        return false;
+      }
+
+      const cacheKey = `${BOOKMARK_CACHE_PREFIX}${userId}`;
+      const wasBookmarked = bookmarkedSet.has(providerId);
+
+      // Optimistic: update UI immediately
+      setBookmarkedIds((prev) => {
+        const next = wasBookmarked
+          ? prev.filter((id) => id !== providerId)
+          : [providerId, ...prev]; // Newest first
+        // Fire-and-forget cache update
+        AsyncStorage.setItem(cacheKey, JSON.stringify(next)).catch(() => {});
+        return next;
+      });
+
+      // Also update the providers list optimistically if it's loaded
+      if (wasBookmarked) {
+        setBookmarkedProviders((prev) =>
+          prev.filter((p) => String(p.id) !== providerId)
+        );
+      }
+
+      // Sync to Firestore
+      try {
+        if (wasBookmarked) {
+          await bookmarkRepository.removeBookmark(userId, providerId);
+        } else {
+          await bookmarkRepository.addBookmark(userId, providerId);
+        }
+        return true;
+      } catch (error) {
+        console.error('Error toggling bookmark:', error);
+
+        // Rollback optimistic update on failure
+        setBookmarkedIds((prev) => {
+          const rolledBack = wasBookmarked
+            ? [providerId, ...prev]
+            : prev.filter((id) => id !== providerId);
+          AsyncStorage.setItem(cacheKey, JSON.stringify(rolledBack)).catch(() => {});
+          return rolledBack;
+        });
+
+        return false;
+      }
+    },
+    [userId, bookmarkedSet]
+  );
+
+  // ─── Fetch full provider details (lazy, for Saved screen) ───────────
+  const fetchBookmarkedProviders = useCallback(async () => {
+    if (!userId) {
+      setBookmarkedProviders([]);
+      return;
+    }
+
+    setIsLoadingProviders(true);
+    try {
+      // Pass already-loaded IDs to avoid a redundant Firestore read
+      const providers = await bookmarkRepository.getBookmarkedProviders(
+        userId,
+        null,
+        bookmarkedIds.length > 0 ? bookmarkedIds : undefined
+      );
+      setBookmarkedProviders(providers);
+    } catch (error) {
+      console.error('Error fetching bookmarked providers:', error);
+    } finally {
+      setIsLoadingProviders(false);
+    }
+  }, [userId, bookmarkedIds]);
+
+  // ─── Context value ──────────────────────────────────────────────────
+  const value = useMemo<BookmarkContextType>(
+    () => ({
+      bookmarkedIds,
+      isBookmarked,
+      toggleBookmark,
+      bookmarkedProviders,
+      fetchBookmarkedProviders,
+      isLoading,
+      isLoadingProviders,
+    }),
+    [bookmarkedIds, isBookmarked, toggleBookmark, bookmarkedProviders, fetchBookmarkedProviders, isLoading, isLoadingProviders]
+  );
+
+  return (
+    <BookmarkContext.Provider value={value}>
+      {children}
+    </BookmarkContext.Provider>
+  );
+}
+

--- a/apps/mobile/hooks/useBookmarks.ts
+++ b/apps/mobile/hooks/useBookmarks.ts
@@ -1,79 +1,30 @@
-import { useState, useEffect, useCallback } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useBookmarkContext } from '@/contexts/bookmarks';
 
-// TODO: Replace with API endpoints when backend is ready
-// API Endpoints: 
-// - GET /api/users/bookmarks - Get all bookmarked providers
-// - POST /api/users/bookmarks/{providerId} - Add bookmark
-// - DELETE /api/users/bookmarks/{providerId} - Remove bookmark
-
-const BOOKMARK_PROVIDERS_KEY = 'bookmarked_providers';
-
+/**
+ * Convenience hook for bookmark functionality.
+ * Thin wrapper around BookmarkContext — all consumers share the same state.
+ *
+ * Bookmarks are stored as string[] on the User document (users/{userId}.bookmarked).
+ * AsyncStorage provides offline-first caching.
+ */
 export function useBookmarks() {
-  const [bookmarkedProviders, setBookmarkedProviders] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  // Load all bookmarked providers
-  useEffect(() => {
-    const loadBookmarks = async () => {
-      try {
-        setIsLoading(true);
-        
-        // TODO: Replace with API call
-        // const response = await apiClient.get('/api/users/bookmarks');
-        // const providers = response.data;
-        
-        const storedBookmarks = await AsyncStorage.getItem(BOOKMARK_PROVIDERS_KEY);
-        const providers = storedBookmarks ? JSON.parse(storedBookmarks) : [];
-        
-        setBookmarkedProviders(providers);
-      } catch (error) {
-        console.error('Error loading bookmarks:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadBookmarks();
-  }, []);
-
-  // Check if a provider is bookmarked
-  const isBookmarked = useCallback((providerId: string) => {
-    return bookmarkedProviders.includes(providerId);
-  }, [bookmarkedProviders]);
-
-  // Toggle bookmark status
-  const toggleBookmark = useCallback(async (providerId: string) => {
-    try {
-      let updatedBookmarks: string[];
-      
-      if (isBookmarked(providerId)) {
-        // TODO: Replace with API call
-        // await apiClient.delete(`/api/users/bookmarks/${providerId}`);
-        
-        updatedBookmarks = bookmarkedProviders.filter(id => id !== providerId);
-      } else {
-        // TODO: Replace with API call
-        // await apiClient.post(`/api/users/bookmarks/${providerId}`);
-        
-        updatedBookmarks = [...bookmarkedProviders, providerId];
-      }
-      
-      // This will be handled by the API in the future
-      await AsyncStorage.setItem(BOOKMARK_PROVIDERS_KEY, JSON.stringify(updatedBookmarks));
-      
-      setBookmarkedProviders(updatedBookmarks);
-      return true;
-    } catch (error) {
-      console.error('Error toggling bookmark:', error);
-      return false;
-    }
-  }, [bookmarkedProviders, isBookmarked]);
-
-  return {
-    bookmarkedProviders,
+  const {
+    bookmarkedIds,
     isBookmarked,
     toggleBookmark,
-    isLoading
+    bookmarkedProviders,
+    fetchBookmarkedProviders,
+    isLoading,
+    isLoadingProviders,
+  } = useBookmarkContext();
+
+  return {
+    bookmarkedIds,
+    isBookmarked,
+    toggleBookmark,
+    bookmarkedProviders,
+    fetchBookmarkedProviders,
+    isLoading,
+    isLoadingProviders,
   };
 }

--- a/apps/mobile/repositories/bookmarkRepository.ts
+++ b/apps/mobile/repositories/bookmarkRepository.ts
@@ -1,0 +1,65 @@
+import * as BookmarkService from "@/backend/main/src/services/bookmarkService";
+import { getProviderViewModel } from "@/repositories/providerRepository";
+import { ProviderViewModel } from "@/types/provider";
+import { Coordinates } from "@/backend/main/src/utils/geo";
+
+/**
+ * Bookmark Repository — Transforms bookmark data for UI consumption
+ *
+ * Reads provider IDs from users/{userId}.bookmarked (string[]),
+ * then fetches full ProviderViewModels for the Saved Providers screen.
+ */
+
+/**
+ * Get all bookmarked provider IDs for a user.
+ */
+export async function getBookmarkedIds(userId: string): Promise<string[]> {
+  return BookmarkService.getBookmarkedProviderIds(userId);
+}
+
+/**
+ * Get full ProviderViewModel data for all bookmarked providers.
+ * Fetches in parallel. Silently filters out providers that no longer exist.
+ *
+ * @param userId - The user whose bookmarks to fetch
+ * @param userLocation - Optional location for distance calculation
+ * @param prefetchedIds - Optional pre-fetched bookmark IDs to avoid a redundant Firestore read
+ */
+export async function getBookmarkedProviders(
+  userId: string,
+  userLocation?: Coordinates | null,
+  prefetchedIds?: string[]
+): Promise<ProviderViewModel[]> {
+  const providerIds = prefetchedIds ?? await BookmarkService.getBookmarkedProviderIds(userId);
+
+  if (providerIds.length === 0) {
+    return [];
+  }
+
+  const results = await Promise.allSettled(
+    providerIds.map((id) => getProviderViewModel(id, userLocation))
+  );
+
+  return results
+    .filter(
+      (r): r is PromiseFulfilledResult<ProviderViewModel | null> =>
+        r.status === "fulfilled" && r.value !== null
+    )
+    .map((r) => r.value!);
+}
+
+/**
+ * Add a bookmark for a provider.
+ */
+export async function addBookmark(userId: string, providerId: string): Promise<void> {
+  return BookmarkService.addBookmark(userId, providerId);
+}
+
+/**
+ * Remove a bookmark for a provider.
+ */
+export async function removeBookmark(userId: string, providerId: string): Promise<void> {
+  return BookmarkService.removeBookmark(userId, providerId);
+}
+
+

--- a/apps/mobile/repositories/index.ts
+++ b/apps/mobile/repositories/index.ts
@@ -13,6 +13,7 @@
  */
 
 export * as bookingRepository from './bookingRepository';
+export * as bookmarkRepository from './bookmarkRepository';
 export * as messageRepository from './messageRepository';
 export * as reviewRepository from './reviewRepository';
 export * as providerRepository from './providerRepository';

--- a/apps/mobile/utils/auth.ts
+++ b/apps/mobile/utils/auth.ts
@@ -1,0 +1,31 @@
+import { Alert } from 'react-native';
+import { router } from 'expo-router';
+
+/**
+ * Checks if a user is authenticated before performing an action.
+ * Shows a standardised "Sign in required" alert with a redirect to login if not.
+ *
+ * @param userId  - The current user's UID (or undefined/null if not signed in)
+ * @param message - Custom message to display (defaults to generic prompt)
+ * @returns `true` if authenticated, `false` if the sign-in alert was shown
+ *
+ * Usage:
+ *   if (!requireAuth(currentUserId, 'Please sign in to save providers.')) return;
+ */
+export function requireAuth(
+  userId: string | undefined | null,
+  message = 'Please sign in to continue.'
+): boolean {
+  if (userId) return true;
+
+  Alert.alert(
+    'Sign in required',
+    message,
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Sign In', onPress: () => router.push('/(auth)/login') },
+    ]
+  );
+  return false;
+}
+


### PR DESCRIPTION
- Change User.bookmarked from DocumentReference[] to string[] for simpler storage
- Add bookmarkService using Firestore arrayUnion/arrayRemove for atomic toggles
- Add bookmarkRepository to fetch full provider ViewModels for saved screen
- Add BookmarkContext for shared state across all screens with optimistic UI updates, rollback on failure, and user-scoped AsyncStorage offline cache
- Rewrite useBookmarks hook as thin context wrapper (replaces isolated AsyncStorage-only impl)
- Rewrite Saved Providers screen with real data, loading states, and pull-to-refresh (removes hardcoded mock data and wrong AsyncStorage key)
- Wire BookmarkProvider into root layout inside AuthProvider
- Add auth gate on bookmark tap across ProviderListItem and provider profile
- Extract shared requireAuth() utility to utils/auth.ts, replacing 10+ duplicated Alert.alert sign-in patterns across provider profile, reviews, and components